### PR TITLE
🎨 Palette: [Accessibility and Polish]

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-05-15 - [Accessibility & Polish in South Shields Metro Times]
+**Learning:** For a single-page app displaying real-time updates (like transport schedules), ARIA attributes like `aria-live="polite"` are crucial for ensuring users with screen readers are kept informed of status changes. Similarly, semantic HTML (like `<ul>` for lists of times) is a key accessibility win that provides context about the number of upcoming events.
+**Action:** Always check if dynamic content areas should have `aria-live` and ensure that repeated content is grouped in semantic elements (like lists) rather than just being separated by `<br>` tags.

--- a/index.html
+++ b/index.html
@@ -30,6 +30,7 @@
         .analysis-content { color: #2c3e50; line-height: 1.6; font-size: 1.2em; font-weight: 500; }
         .analysis-timestamp { color: #7f8c8d; font-size: 0.9em; margin-top: 12px; padding-top: 12px; border-top: 1px solid #ecf0f1; }
         #scheduled-times { font-size: 1.4em; line-height: 1.8; }
+        #scheduled-times ul { list-style: none; padding: 0; margin: 0; }
         .static-note { 
             background: #fff3cd; border: 1px solid #ffeaa7; border-radius: 8px; 
             padding: 16px; margin-top: 20px; font-size: 0.95em; color: #856404; 
@@ -40,16 +41,16 @@
 <body>
     <h1 style="text-align: center;">South Shields Metro Departures</h1>
     
-    <div id="predicted-departure">Predicted next departure time: <span id="prediction-time">Loading...</span></div>
+    <div id="predicted-departure">Predicted next departure time: <span id="prediction-time" aria-live="polite">Loading...</span></div>
     
     <div class="card">
         <h2>Next Scheduled Times</h2>
-        <div id="scheduled-times">Loading...</div>
+        <div id="scheduled-times" aria-live="polite">Loading...</div>
     </div>
     
     <div class="service-analysis">
-        <h2><span class="status-indicator status-info" id="statusIndicator"></span>Next scheduled Departure:</h2>
-        <div id="analysisContent" class="analysis-content">Loading...</div>
+        <h2><span class="status-indicator status-info" id="statusIndicator" aria-label="Service status: Information"></span>Next scheduled Departure:</h2>
+        <div id="analysisContent" class="analysis-content" aria-live="polite">Loading...</div>
         <div class="analysis-timestamp" id="analysisTimestamp"></div>
     </div>
     
@@ -98,7 +99,7 @@
             const scheduledDiv = document.getElementById('scheduled-times');
             const nextTimes = getNextScheduledTimes();
             scheduledDiv.innerHTML = nextTimes.length > 0 
-                ? nextTimes.map(t => `${t.hour.toString().padStart(2,'0')}:${t.minute.toString().padStart(2,'0')}`).join('<br>')
+                ? `<ul>${nextTimes.map(t => `<li>${t.hour.toString().padStart(2,'0')}:${t.minute.toString().padStart(2,'0')}</li>`).join('')}</ul>`
                 : 'No more scheduled departures today';
         }
 
@@ -144,7 +145,8 @@
             } else {
                 const next = nextScheduled[0];
                 const minsUntil = next.hour * 60 + next.minute - (now.getHours() * 60 + now.getMinutes());
-                analysisContent.textContent = `${next.hour.toString().padStart(2,'0')}:${next.minute.toString().padStart(2,'0')} (${minsUntil} mins)`;
+                const unit = minsUntil === 1 ? 'min' : 'mins';
+                analysisContent.textContent = `${next.hour.toString().padStart(2,'0')}:${next.minute.toString().padStart(2,'0')} (${minsUntil} ${unit})`;
                 statusIndicator.className = 'status-indicator status-info';
             }
             


### PR DESCRIPTION
Enhanced the accessibility and micro-UX of the metro departures interface. Key improvements include:
1.  **Semantic List**: Converted the list of next scheduled times from a text block with line breaks into a semantic `<ul>` element. This allows screen readers to announce the number of upcoming departures.
2.  **Dynamic Announcements**: Added `aria-live="polite"` to all areas that update automatically every 15 seconds, ensuring screen reader users are notified of changes.
3.  **Pluralization Polish**: Fixed a minor UX issue where "1 mins" would be displayed; it now correctly shows "1 min".
4.  **Status Context**: Added an `aria-label` to the color-coded status indicator dot to provide context for visually impaired users.
5.  **Maintainability**: Documented these patterns in a new `.Jules/palette.md` journal.

---
*PR created automatically by Jules for task [6539707329060398940](https://jules.google.com/task/6539707329060398940) started by @ColinPattinson*