### PR TITLE
🎨 Palette: UX and accessibility improvements for metro departures

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-04-02 - [Initial Accessibility and UX Review]
+**Learning:** The application lacks `aria-live` regions for dynamic content, leading to screen reader users missing live updates. Additionally, simple minute counts (e.g., "1 mins") were discovered, highlighting the need for conditional pluralization.
+**Action:** Implement `aria-live="polite"` on all dynamic time displays and use conditional logic for unit pluralization in future components.

--- a/index.html
+++ b/index.html
@@ -35,21 +35,34 @@
             padding: 16px; margin-top: 20px; font-size: 0.95em; color: #856404; 
             text-align: center;
         }
+        .sr-only {
+            position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px;
+            overflow: hidden; clip: rect(0, 0, 0, 0); white-space: nowrap; border: 0;
+        }
+        .refresh-btn {
+            display: block; margin: 10px auto; padding: 8px 16px;
+            background: #3498db; color: white; border: none; border-radius: 4px;
+            cursor: pointer; font-size: 1rem; transition: background 0.2s;
+        }
+        .refresh-btn:hover { background: #2980b9; }
+        .refresh-btn:focus { outline: 2px solid #2c3e50; outline-offset: 2px; }
+        .refresh-btn:disabled { background: #95a5a6; cursor: not-allowed; }
     </style>
 </head>
 <body>
     <h1 style="text-align: center;">South Shields Metro Departures</h1>
+    <button id="refreshBtn" class="refresh-btn" aria-label="Refresh departure times">Refresh Times</button>
     
-    <div id="predicted-departure">Predicted next departure time: <span id="prediction-time">Loading...</span></div>
+    <div id="predicted-departure">Predicted next departure time: <span id="prediction-time" aria-live="polite">Loading...</span></div>
     
     <div class="card">
         <h2>Next Scheduled Times</h2>
-        <div id="scheduled-times">Loading...</div>
+        <div id="scheduled-times" aria-live="polite">Loading...</div>
     </div>
     
     <div class="service-analysis">
-        <h2><span class="status-indicator status-info" id="statusIndicator"></span>Next scheduled Departure:</h2>
-        <div id="analysisContent" class="analysis-content">Loading...</div>
+        <h2><span class="status-indicator status-info" id="statusIndicator" role="img" aria-label="Service status: information"></span>Next scheduled Departure:</h2>
+        <div id="analysisContent" class="analysis-content" aria-live="polite">Loading...</div>
         <div class="analysis-timestamp" id="analysisTimestamp"></div>
     </div>
     
@@ -81,7 +94,7 @@
             const schedule = getScheduleForDay();
             let upcomingTimes = [];
             if (schedule[currentHour]) {
-                const validMinutes = schedule[currentHour].filter(m => m > currentMinute);
+                const validMinutes = schedule[currentHour].filter(m => m >= currentMinute);
                 upcomingTimes.push(...validMinutes.map(m => ({hour: currentHour, minute: m})));
             }
             let hour = currentHour + 1;
@@ -141,15 +154,33 @@
             if (nextScheduled.length === 0) {
                 analysisContent.textContent = 'Service has ended for the day.';
                 statusIndicator.className = 'status-indicator status-info';
+                statusIndicator.setAttribute('aria-label', 'Service status: information - Service ended');
             } else {
                 const next = nextScheduled[0];
                 const minsUntil = next.hour * 60 + next.minute - (now.getHours() * 60 + now.getMinutes());
-                analysisContent.textContent = `${next.hour.toString().padStart(2,'0')}:${next.minute.toString().padStart(2,'0')} (${minsUntil} mins)`;
+                const timeStr = `${next.hour.toString().padStart(2,'0')}:${next.minute.toString().padStart(2,'0')}`;
+                const relativeStr = minsUntil === 0 ? 'Due now' : `${minsUntil} ${minsUntil === 1 ? 'min' : 'mins'}`;
+                analysisContent.textContent = `${timeStr} (${relativeStr})`;
                 statusIndicator.className = 'status-indicator status-info';
+                statusIndicator.setAttribute('aria-label', `Service status: information - Next train ${relativeStr}`);
             }
             
             timestampDiv.textContent = `Updated: ${now.toLocaleTimeString('en-GB')}`;
         }
+
+        // Refresh button logic
+        const refreshBtn = document.getElementById('refreshBtn');
+        refreshBtn.addEventListener('click', async () => {
+            const originalText = refreshBtn.textContent;
+            refreshBtn.disabled = true;
+            refreshBtn.textContent = 'Refreshing...';
+            try {
+                await updateAll();
+            } finally {
+                refreshBtn.disabled = false;
+                refreshBtn.textContent = originalText;
+            }
+        });
 
         // Load everything
         async function updateAll() {


### PR DESCRIPTION
🎨 Palette: UX and accessibility improvements for metro departures

This PR introduces several micro-UX and accessibility enhancements to the South Shields Metro Departures page. Key changes include:
- **Manual Refresh:** A new button to manually update the times, providing visual feedback with a "Refreshing..." state.
- **Accessibility:** Added `aria-live="polite"` to all dynamic areas and a descriptive `aria-label` with `role="img"` to the color-coded status indicator.
- **Micro-UX:** Corrected pluralization logic (e.g., "1 min" instead of "1 mins") and introduced a "Due now" state for trains leaving in 0 minutes.
- **Logic Fix:** Adjusted the upcoming times filter to include trains due in the current minute, preventing them from disappearing prematurely.
- **Utility:** Added a `.sr-only` CSS class for screen-reader-only text.
- **Journal:** Initialized the `.Jules/palette.md` journal with learnings from this task.

All changes are under 50 lines and follow the Palette 🎨 philosophy of making the interface more intuitive, accessible, and pleasant.

---
*PR created automatically by Jules for task [1573518152412101492](https://jules.google.com/task/1573518152412101492) started by @ColinPattinson*