### PR TITLE
🎨 Palette: Improve accessibility and countdown clarity

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-05-22 - Improving Real-Time Accessibility for Static Transit Apps
+**Learning:** For single-page static transit apps with periodic polling (e.g., every 15s), using `aria-live="polite"` on dynamic time displays is crucial for ensuring screen reader users are notified of updates without interrupting their current task. Additionally, including the current minute in departure logic (e.g., `m >= currentMinute`) avoids the common "disappearing train" bug where a train at the platform is hidden from the UI.
+**Action:** Always check if filter logic is inclusive of the current time and ensure dynamic regions have appropriate ARIA live attributes.

--- a/index.html
+++ b/index.html
@@ -35,21 +35,28 @@
             padding: 16px; margin-top: 20px; font-size: 0.95em; color: #856404; 
             text-align: center;
         }
+        .sr-only {
+            position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px;
+            overflow: hidden; clip: rect(0, 0, 0, 0); white-space: nowrap; border-width: 0;
+        }
     </style>
 </head>
 <body>
     <h1 style="text-align: center;">South Shields Metro Departures</h1>
     
-    <div id="predicted-departure">Predicted next departure time: <span id="prediction-time">Loading...</span></div>
+    <div id="predicted-departure">Predicted next departure time: <span id="prediction-time" aria-live="polite">Loading...</span></div>
     
     <div class="card">
         <h2>Next Scheduled Times</h2>
-        <div id="scheduled-times">Loading...</div>
+        <div id="scheduled-times" aria-live="polite">Loading...</div>
     </div>
     
     <div class="service-analysis">
-        <h2><span class="status-indicator status-info" id="statusIndicator"></span>Next scheduled Departure:</h2>
-        <div id="analysisContent" class="analysis-content">Loading...</div>
+        <h2>
+            <span class="status-indicator status-info" id="statusIndicator" role="img" aria-label="Service Status: Info"></span>
+            Next scheduled Departure:
+        </h2>
+        <div id="analysisContent" class="analysis-content" aria-live="polite">Loading...</div>
         <div class="analysis-timestamp" id="analysisTimestamp"></div>
     </div>
     
@@ -81,7 +88,7 @@
             const schedule = getScheduleForDay();
             let upcomingTimes = [];
             if (schedule[currentHour]) {
-                const validMinutes = schedule[currentHour].filter(m => m > currentMinute);
+                const validMinutes = schedule[currentHour].filter(m => m >= currentMinute);
                 upcomingTimes.push(...validMinutes.map(m => ({hour: currentHour, minute: m})));
             }
             let hour = currentHour + 1;
@@ -141,11 +148,22 @@
             if (nextScheduled.length === 0) {
                 analysisContent.textContent = 'Service has ended for the day.';
                 statusIndicator.className = 'status-indicator status-info';
+                statusIndicator.setAttribute('aria-label', 'Service Status: Info');
             } else {
                 const next = nextScheduled[0];
                 const minsUntil = next.hour * 60 + next.minute - (now.getHours() * 60 + now.getMinutes());
-                analysisContent.textContent = `${next.hour.toString().padStart(2,'0')}:${next.minute.toString().padStart(2,'0')} (${minsUntil} mins)`;
+                const timeStr = `${next.hour.toString().padStart(2,'0')}:${next.minute.toString().padStart(2,'0')}`;
+
+                let countdownStr = '';
+                if (minsUntil === 0) {
+                    countdownStr = 'Due now';
+                } else {
+                    countdownStr = `${minsUntil} ${minsUntil === 1 ? 'min' : 'mins'}`;
+                }
+
+                analysisContent.textContent = `${timeStr} (${countdownStr})`;
                 statusIndicator.className = 'status-indicator status-info';
+                statusIndicator.setAttribute('aria-label', 'Service Status: Good');
             }
             
             timestampDiv.textContent = `Updated: ${now.toLocaleTimeString('en-GB')}`;


### PR DESCRIPTION
I've implemented several micro-UX improvements to the South Shields Metro Times interface:

1.  **Accessibility Enhancements**:
    *   Added `aria-live="polite"` to dynamic regions (`#prediction-time`, `#scheduled-times`, `#analysisContent`) to ensure screen readers announce updates every 15 seconds.
    *   Added `role="img"` and a dynamic `aria-label` (e.g., "Service Status: Good") to the color-coded status indicator, making its state perceivable to all users.
    *   Included a `.sr-only` CSS utility class for visually hidden but accessible text.

2.  **Countdown Clarity**:
    *   Updated the countdown timer to show "Due now" instead of "0 mins" for immediate departures.
    *   Implemented proper pluralization for minute counts (e.g., "1 min" vs. "2 mins").

3.  **Logical Consistency**:
    *   Modified the departure filtering logic to include trains in the current minute (`m >= currentMinute`), ensuring users don't miss departures that are currently at the platform.

These changes make the application more inclusive, intuitive, and reliable.


---
*PR created automatically by Jules for task [5822123513572807194](https://jules.google.com/task/5822123513572807194) started by @ColinPattinson*