### PR TITLE
🎨 Palette: Enhance accessibility and clarity of Metro departures

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-05-14 - Transit Countdown Clarity and Accessibility
+**Learning:** For countdowns or time-until displays, users appreciate "Due now" instead of "0 mins" for clarity. Additionally, ensuring screen readers receive updates via `aria-live` and have semantic context for status indicators via `role="img"` and `aria-label` significantly improves accessibility.
+**Action:** Always implement conditional pluralization and "Due now" labels in countdowns. Use `aria-live="polite"` for dynamic content sections and provide descriptive `aria-label` for color-coded status elements.

--- a/index.html
+++ b/index.html
@@ -40,16 +40,16 @@
 <body>
     <h1 style="text-align: center;">South Shields Metro Departures</h1>
     
-    <div id="predicted-departure">Predicted next departure time: <span id="prediction-time">Loading...</span></div>
+    <div id="predicted-departure">Predicted next departure time: <span id="prediction-time" aria-live="polite">Loading...</span></div>
     
     <div class="card">
         <h2>Next Scheduled Times</h2>
-        <div id="scheduled-times">Loading...</div>
+        <div id="scheduled-times" aria-live="polite">Loading...</div>
     </div>
     
     <div class="service-analysis">
-        <h2><span class="status-indicator status-info" id="statusIndicator"></span>Next scheduled Departure:</h2>
-        <div id="analysisContent" class="analysis-content">Loading...</div>
+        <h2><span class="status-indicator status-info" id="statusIndicator" role="img" aria-label="Service Status: Normal"></span>Next scheduled Departure:</h2>
+        <div id="analysisContent" class="analysis-content" aria-live="polite">Loading...</div>
         <div class="analysis-timestamp" id="analysisTimestamp"></div>
     </div>
     
@@ -81,7 +81,7 @@
             const schedule = getScheduleForDay();
             let upcomingTimes = [];
             if (schedule[currentHour]) {
-                const validMinutes = schedule[currentHour].filter(m => m > currentMinute);
+                const validMinutes = schedule[currentHour].filter(m => m >= currentMinute);
                 upcomingTimes.push(...validMinutes.map(m => ({hour: currentHour, minute: m})));
             }
             let hour = currentHour + 1;
@@ -141,11 +141,22 @@
             if (nextScheduled.length === 0) {
                 analysisContent.textContent = 'Service has ended for the day.';
                 statusIndicator.className = 'status-indicator status-info';
+                statusIndicator.setAttribute('aria-label', 'Service Status: Service has ended');
             } else {
                 const next = nextScheduled[0];
                 const minsUntil = next.hour * 60 + next.minute - (now.getHours() * 60 + now.getMinutes());
-                analysisContent.textContent = `${next.hour.toString().padStart(2,'0')}:${next.minute.toString().padStart(2,'0')} (${minsUntil} mins)`;
+                const timeStr = `${next.hour.toString().padStart(2,'0')}:${next.minute.toString().padStart(2,'0')}`;
+
+                let displayMins;
+                if (minsUntil === 0) {
+                    displayMins = 'Due now';
+                } else {
+                    displayMins = `${minsUntil} ${minsUntil === 1 ? 'min' : 'mins'}`;
+                }
+
+                analysisContent.textContent = `${timeStr} (${displayMins})`;
                 statusIndicator.className = 'status-indicator status-info';
+                statusIndicator.setAttribute('aria-label', 'Service Status: On schedule');
             }
             
             timestampDiv.textContent = `Updated: ${now.toLocaleTimeString('en-GB')}`;


### PR DESCRIPTION
This PR introduces several micro-UX and accessibility improvements to the South Shields Metro Departures page.

💡 What:
- Added `aria-live="polite"` to elements that update dynamically (`#prediction-time`, `#scheduled-times`, `#analysisContent`) so screen reader users are notified of updates.
- Added `role="img"` and a dynamic `aria-label` to the `#statusIndicator` dot to communicate service status to assistive technology.
- Updated `getNextScheduledTimes` to be inclusive of the current minute, ensuring that a train departing "now" is still shown.
- Refined the countdown display to show "Due now" instead of "0 mins" and added proper pluralization for "1 min" vs "mins".

🎯 Why:
- Previous implementation was missing critical accessibility markers for dynamic content.
- Countdown logic was inconsistent with real-world transit app expectations (omitting immediate departures and lacking "Due now" clarity).
- Color-coded status was inaccessible to screen readers.

♿ Accessibility:
- Full support for screen readers via `aria-live` and `aria-label`.
- Semantic roles added to visual indicators.

📸 Before/After:
[Verification Screenshot Included] - Shows "07:08 (Due now)" when the time is exactly 07:08.

---
*PR created automatically by Jules for task [2923165210653164338](https://jules.google.com/task/2923165210653164338) started by @ColinPattinson*