### PR TITLE
🎨 Palette: Manual Refresh & Accessibility Enhancements

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,7 @@
+## 2025-05-14 - Pluralization and Immediate States in Transit Countdowns
+**Learning:** Transit countdowns are more intuitive when they display "Due now" for 0-minute waits and use correct pluralization (min vs mins) for other values.
+**Action:** Always implement conditional logic for time-based displays: `minsUntil === 0 ? 'Due now' : `${minsUntil} ${minsUntil === 1 ? 'min' : 'mins'}``.
+
+## 2025-05-14 - Screen Reader Visibility for Dynamic Content
+**Learning:** Dynamic updates in single-page applications are often missed by screen readers unless explicitly marked with `aria-live="polite"`.
+**Action:** Ensure all elements that update via JavaScript (timers, status indicators, analysis results) have appropriate ARIA live regions.

--- a/index.html
+++ b/index.html
@@ -35,12 +35,25 @@
             padding: 16px; margin-top: 20px; font-size: 0.95em; color: #856404; 
             text-align: center;
         }
+        #refresh-button {
+            background: #2c3e50; color: white; border: none; padding: 10px 20px;
+            border-radius: 4px; cursor: pointer; font-size: 1rem; transition: background 0.2s;
+        }
+        #refresh-button:hover:not(:disabled) { background: #34495e; }
+        #refresh-button:disabled { background: #95a5a6; cursor: not-allowed; }
+        .sr-only {
+            position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px;
+            overflow: hidden; clip: rect(0, 0, 0, 0); white-space: nowrap; border-width: 0;
+        }
     </style>
 </head>
 <body>
     <h1 style="text-align: center;">South Shields Metro Departures</h1>
     
-    <div id="predicted-departure">Predicted next departure time: <span id="prediction-time">Loading...</span></div>
+    <div id="predicted-departure">
+        Predicted next departure time: <span id="prediction-time" aria-live="polite">Loading...</span>
+        <span id="prediction-source" class="sr-only">Checking service data...</span>
+    </div>
     
     <div class="card">
         <h2>Next Scheduled Times</h2>
@@ -48,13 +61,15 @@
     </div>
     
     <div class="service-analysis">
-        <h2><span class="status-indicator status-info" id="statusIndicator"></span>Next scheduled Departure:</h2>
-        <div id="analysisContent" class="analysis-content">Loading...</div>
-        <div class="analysis-timestamp" id="analysisTimestamp"></div>
+        <h2><span class="status-indicator status-info" id="statusIndicator" role="img" aria-label="Service Status: Normal"></span>Next scheduled Departure:</h2>
+        <div id="analysisContent" class="analysis-content" aria-live="polite">Loading...</div>
+        <div class="analysis-timestamp" id="analysisTimestamp" aria-live="polite"></div>
     </div>
     
     <div class="static-note">
         <strong>Live data:</strong> Via Cloudflare Worker proxy. Falls back to static schedule if unavailable. Auto-refreshes every 15s.
+        <br><br>
+        <button id="refresh-button" onclick="updateAll(true)" aria-label="Refresh departures">Refresh Now</button>
     </div>
 
     <script>
@@ -81,7 +96,7 @@
             const schedule = getScheduleForDay();
             let upcomingTimes = [];
             if (schedule[currentHour]) {
-                const validMinutes = schedule[currentHour].filter(m => m > currentMinute);
+                const validMinutes = schedule[currentHour].filter(m => m >= currentMinute);
                 upcomingTimes.push(...validMinutes.map(m => ({hour: currentHour, minute: m})));
             }
             let hour = currentHour + 1;
@@ -116,18 +131,21 @@
         async function fetchPrediction() {
             const data = await fetchLiveData('/api/times/CHI/2');
             const predictionSpan = document.getElementById('prediction-time');
+            const sourceSpan = document.getElementById('prediction-source');
             
             if (data && data.length > 0) {
                 const now = new Date();
                 const predictedTime = new Date(now.getTime() + (data[0].dueIn - 2) * 60000);
                 predictionSpan.textContent = `${predictedTime.getHours().toString().padStart(2,'0')}:${predictedTime.getMinutes().toString().padStart(2,'0')}`;
                 predictionSpan.parentElement.style.background = '#27ae60'; // Green when live
+                if (sourceSpan) sourceSpan.textContent = '(Live real-time data)';
             } else {
                 const nextTimes = getNextScheduledTimes();
                 predictionSpan.textContent = nextTimes.length > 0 
                     ? `${nextTimes[0].hour.toString().padStart(2,'0')}:${nextTimes[0].minute.toString().padStart(2,'0')}`
                     : 'No departures';
                 predictionSpan.parentElement.style.background = '#3498db'; // Blue when static
+                if (sourceSpan) sourceSpan.textContent = '(Scheduled timetable data)';
             }
         }
 
@@ -141,21 +159,44 @@
             if (nextScheduled.length === 0) {
                 analysisContent.textContent = 'Service has ended for the day.';
                 statusIndicator.className = 'status-indicator status-info';
+                statusIndicator.setAttribute('aria-label', 'Service Status: Information');
             } else {
                 const next = nextScheduled[0];
                 const minsUntil = next.hour * 60 + next.minute - (now.getHours() * 60 + now.getMinutes());
-                analysisContent.textContent = `${next.hour.toString().padStart(2,'0')}:${next.minute.toString().padStart(2,'0')} (${minsUntil} mins)`;
+
+                let timeString;
+                if (minsUntil === 0) {
+                    timeString = `${next.hour.toString().padStart(2,'0')}:${next.minute.toString().padStart(2,'0')} (Due now)`;
+                } else {
+                    timeString = `${next.hour.toString().padStart(2,'0')}:${next.minute.toString().padStart(2,'0')} (${minsUntil} ${minsUntil === 1 ? 'min' : 'mins'})`;
+                }
+
+                analysisContent.textContent = timeString;
                 statusIndicator.className = 'status-indicator status-info';
+                statusIndicator.setAttribute('aria-label', 'Service Status: Normal');
             }
             
             timestampDiv.textContent = `Updated: ${now.toLocaleTimeString('en-GB')}`;
         }
 
         // Load everything
-        async function updateAll() {
-            displayScheduledTimes();
-            await fetchPrediction();
-            analyzeService();
+        async function updateAll(manual = false) {
+            const btn = document.getElementById('refresh-button');
+            if (manual && btn) {
+                btn.disabled = true;
+                btn.textContent = 'Refreshing...';
+            }
+
+            try {
+                displayScheduledTimes();
+                await fetchPrediction();
+                analyzeService();
+            } finally {
+                if (manual && btn) {
+                    btn.disabled = false;
+                    btn.textContent = 'Refresh Now';
+                }
+            }
         }
         
         updateAll();


### PR DESCRIPTION
This PR implements a suite of micro-UX and accessibility improvements to the South Shields Metro Departures interface.

### 💡 What:
- **Manual Refresh Button:** Users can now manually trigger a data update. The button provides clear feedback by disabling and changing text to "Refreshing..." during the operation.
- **Improved Countdown Logic:** Departures in the current minute now show as "Due now", and pluralization for "1 min" vs "X mins" is correctly handled.
- **Accessibility (a11y) Upgrades:**
    - `aria-live="polite"` added to critical dynamic fields to notify screen reader users of updates.
    - `role="img"` and dynamic `aria-label` added to the color-coded status indicator.
    - Visually hidden descriptions (.sr-only) clarify if the predicted departure is based on live or static data.
    - Optimized ARIA live regions to avoid repetitive announcements of the entire schedule list.

### 🎯 Why:
- **User Control:** Provides a way to manually sync times without waiting for the 15s auto-refresh.
- **Clarity:** "Due now" is more intuitive than "0 mins" or skipping the current minute.
- **Inclusivity:** Ensures that users relying on assistive technology have the same context as visual users (e.g., status color meaning, data source).

### ♿ Accessibility:
- Screen reader support for dynamic content updates.
- Visual-only status indicators now have text equivalents.
- Keyboard accessible refresh functionality.


---
*PR created automatically by Jules for task [28698473213710896](https://jules.google.com/task/28698473213710896) started by @ColinPattinson*