### PR TITLE
🎨 Palette: Accessibility and UX Improvements

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,7 @@
+## 2026-04-14 - Accessible Contrast for Status Colors
+**Learning:** Standard UI colors like #3498db (blue) and #27ae60 (green) often fail WCAG AA contrast requirements (4.5:1) when paired with white text on light backgrounds or used as border/text colors. Accessible alternatives like #1565c0 and #1b5e20 provide better readability while maintaining the same color intent.
+**Action:** Always verify contrast ratios for status indicators and prediction bars, especially when they contain critical information like departure times.
+
+## 2026-04-14 - Semantic Lists for Departure Times
+**Learning:** Using string joining with `<br>` for lists of times (like departures) is a "flat" structure that prevents screen readers from announcing the total number of items or allowing users to jump between them easily.
+**Action:** Use semantic `<ul>` and `<li>` elements for any list of discrete data points, even if they are styled to look like simple text blocks.

--- a/index.html
+++ b/index.html
@@ -7,15 +7,16 @@
     <style>
         body { font-family: Arial, sans-serif; margin: 20px; }
         #predicted-departure {
-            background: #3498db; color: white; padding: 20px; border-radius: 8px; 
+            background: #1565c0; color: white; padding: 20px; border-radius: 8px;
             margin: 20px 0; font-size: 2em; text-align: center;
         }
         .card { 
             background: #f5f5f5; padding: 20px; border-radius: 8px; margin: 20px 0;
             max-width: 600px; margin-left: auto; margin-right: auto;
         }
+        .card ul { list-style: none; padding: 0; margin: 0; }
         .service-analysis { 
-            background: #fff; border: 2px solid #3498db; border-radius: 8px; 
+            background: #fff; border: 2px solid #1565c0; border-radius: 8px;
             padding: 24px; margin-top: 20px; box-shadow: 0 2px 8px rgba(0,0,0,0.1); 
         }
         .service-analysis h2 { 
@@ -23,10 +24,10 @@
             display: flex; align-items: center; gap: 10px; 
         }
         .status-indicator { width: 12px; height: 12px; border-radius: 50%; display: inline-block; }
-        .status-good { background-color: #27ae60; }
+        .status-good { background-color: #1b5e20; }
         .status-warning { background-color: #f39c12; }
         .status-error { background-color: #e74c3c; }
-        .status-info { background-color: #3498db; }
+        .status-info { background-color: #1565c0; }
         .analysis-content { color: #2c3e50; line-height: 1.6; font-size: 1.2em; font-weight: 500; }
         .analysis-timestamp { color: #7f8c8d; font-size: 0.9em; margin-top: 12px; padding-top: 12px; border-top: 1px solid #ecf0f1; }
         #scheduled-times { font-size: 1.4em; line-height: 1.8; }
@@ -40,7 +41,7 @@
 <body>
     <h1 style="text-align: center;">South Shields Metro Departures</h1>
     
-    <div id="predicted-departure">Predicted next departure time: <span id="prediction-time">Loading...</span></div>
+    <div id="predicted-departure">Predicted next departure time: <span id="prediction-time" aria-live="polite">Loading...</span></div>
     
     <div class="card">
         <h2>Next Scheduled Times</h2>
@@ -48,8 +49,8 @@
     </div>
     
     <div class="service-analysis">
-        <h2><span class="status-indicator status-info" id="statusIndicator"></span>Next scheduled Departure:</h2>
-        <div id="analysisContent" class="analysis-content">Loading...</div>
+        <h2><span class="status-indicator status-info" id="statusIndicator" role="img" aria-label="Status: Information"></span>Next scheduled Departure:</h2>
+        <div id="analysisContent" class="analysis-content" aria-live="polite">Loading...</div>
         <div class="analysis-timestamp" id="analysisTimestamp"></div>
     </div>
     
@@ -98,7 +99,7 @@
             const scheduledDiv = document.getElementById('scheduled-times');
             const nextTimes = getNextScheduledTimes();
             scheduledDiv.innerHTML = nextTimes.length > 0 
-                ? nextTimes.map(t => `${t.hour.toString().padStart(2,'0')}:${t.minute.toString().padStart(2,'0')}`).join('<br>')
+                ? `<ul>${nextTimes.map(t => `<li>${t.hour.toString().padStart(2,'0')}:${t.minute.toString().padStart(2,'0')}</li>`).join('')}</ul>`
                 : 'No more scheduled departures today';
         }
 
@@ -119,15 +120,20 @@
             
             if (data && data.length > 0) {
                 const now = new Date();
-                const predictedTime = new Date(now.getTime() + (data[0].dueIn - 2) * 60000);
-                predictionSpan.textContent = `${predictedTime.getHours().toString().padStart(2,'0')}:${predictedTime.getMinutes().toString().padStart(2,'0')}`;
-                predictionSpan.parentElement.style.background = '#27ae60'; // Green when live
+                const dueIn = data[0].dueIn - 2;
+                if (dueIn <= 0) {
+                    predictionSpan.textContent = "Due now";
+                } else {
+                    const predictedTime = new Date(now.getTime() + dueIn * 60000);
+                    predictionSpan.textContent = `${predictedTime.getHours().toString().padStart(2,'0')}:${predictedTime.getMinutes().toString().padStart(2,'0')}`;
+                }
+                predictionSpan.parentElement.style.background = '#1b5e20'; // Green when live
             } else {
                 const nextTimes = getNextScheduledTimes();
                 predictionSpan.textContent = nextTimes.length > 0 
                     ? `${nextTimes[0].hour.toString().padStart(2,'0')}:${nextTimes[0].minute.toString().padStart(2,'0')}`
                     : 'No departures';
-                predictionSpan.parentElement.style.background = '#3498db'; // Blue when static
+                predictionSpan.parentElement.style.background = '#1565c0'; // Blue when static
             }
         }
 
@@ -141,11 +147,19 @@
             if (nextScheduled.length === 0) {
                 analysisContent.textContent = 'Service has ended for the day.';
                 statusIndicator.className = 'status-indicator status-info';
+                statusIndicator.setAttribute('aria-label', 'Status: Information');
             } else {
                 const next = nextScheduled[0];
                 const minsUntil = next.hour * 60 + next.minute - (now.getHours() * 60 + now.getMinutes());
-                analysisContent.textContent = `${next.hour.toString().padStart(2,'0')}:${next.minute.toString().padStart(2,'0')} (${minsUntil} mins)`;
+                const timeStr = `${next.hour.toString().padStart(2,'0')}:${next.minute.toString().padStart(2,'0')}`;
+
+                if (minsUntil <= 0) {
+                    analysisContent.textContent = `${timeStr} (Due now)`;
+                } else {
+                    analysisContent.textContent = `${timeStr} (${minsUntil} ${minsUntil === 1 ? 'min' : 'mins'})`;
+                }
                 statusIndicator.className = 'status-indicator status-info';
+                statusIndicator.setAttribute('aria-label', 'Status: Information');
             }
             
             timestampDiv.textContent = `Updated: ${now.toLocaleTimeString('en-GB')}`;


### PR DESCRIPTION
### 🎨 Palette: Accessibility and UX Improvements

#### 💡 What
This enhancement improves the accessibility and user experience of the South Shields Metro Departures dashboard. Key changes include updating the color palette for better contrast, adding ARIA attributes for screen readers, and refining the time display logic.

#### 🎯 Why
- The original blue and green colors had insufficient contrast against white text, making them hard to read for some users.
- Screen readers were not notified when departure times updated dynamically.
- Departure times were displayed in a non-semantic flat list, making navigation difficult for assistive technology.
- "0 mins" is less intuitive than "Due now" for commuters.

#### 📸 Before/After
- **Before:** Light blue (#3498db) and green (#27ae60) backgrounds; times separated by line breaks; no screen reader notifications.
- **After:** Accessible dark blue (#1565c0) and dark green (#1b5e20) backgrounds; semantic bulleted list (styled clean); live announcements for updates.

#### ♿ Accessibility
- **Contrast:** Met WCAG AA standards for text and UI components.
- **Semantics:** Converted flat text to a structured list.
- **Dynamic Content:** Added `aria-live` regions to announce time changes.
- **Icons:** Added `role="img"` and `aria-label` to visual status dots.

---
*PR created automatically by Jules for task [11813786432893498971](https://jules.google.com/task/11813786432893498971) started by @ColinPattinson*