### PR TITLE
🎨 Palette: Improve accessibility and add manual refresh

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-04-17 - Accessible Color Contrast & Screen Reader Context
+**Learning:** Standard UI colors like #3498db and #27ae60 often fail WCAG contrast requirements when paired with white text. Additionally, visual state changes (like color shifts to indicate live vs static data) are invisible to screen readers without explicit text context.
+**Action:** Always use darker, accessible color variants (e.g., #1565c0 for blue, #1b5e20 for green) and provide hidden context spans (.sr-only) to describe the state change to assistive technology users.

--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
     <style>
         body { font-family: Arial, sans-serif; margin: 20px; }
         #predicted-departure {
-            background: #3498db; color: white; padding: 20px; border-radius: 8px; 
+            background: #1565c0; color: white; padding: 20px; border-radius: 8px;
             margin: 20px 0; font-size: 2em; text-align: center;
         }
         .card { 
@@ -23,10 +23,10 @@
             display: flex; align-items: center; gap: 10px; 
         }
         .status-indicator { width: 12px; height: 12px; border-radius: 50%; display: inline-block; }
-        .status-good { background-color: #27ae60; }
+        .status-good { background-color: #1b5e20; }
         .status-warning { background-color: #f39c12; }
         .status-error { background-color: #e74c3c; }
-        .status-info { background-color: #3498db; }
+        .status-info { background-color: #1565c0; }
         .analysis-content { color: #2c3e50; line-height: 1.6; font-size: 1.2em; font-weight: 500; }
         .analysis-timestamp { color: #7f8c8d; font-size: 0.9em; margin-top: 12px; padding-top: 12px; border-top: 1px solid #ecf0f1; }
         #scheduled-times { font-size: 1.4em; line-height: 1.8; }
@@ -35,12 +35,34 @@
             padding: 16px; margin-top: 20px; font-size: 0.95em; color: #856404; 
             text-align: center;
         }
+        .sr-only {
+            position: absolute;
+            width: 1px;
+            height: 1px;
+            padding: 0;
+            margin: -1px;
+            overflow: hidden;
+            clip: rect(0, 0, 0, 0);
+            white-space: nowrap;
+            border-width: 0;
+        }
+        #refresh-btn:disabled {
+            opacity: 0.6;
+            cursor: not-allowed;
+        }
     </style>
 </head>
 <body>
     <h1 style="text-align: center;">South Shields Metro Departures</h1>
+
+    <div style="text-align: center; margin-bottom: 20px;">
+        <button id="refresh-btn" aria-label="Refresh times" style="padding: 8px 16px; border-radius: 4px; border: 1px solid #ccc; background: #fff; cursor: pointer;">Refresh</button>
+    </div>
     
-    <div id="predicted-departure">Predicted next departure time: <span id="prediction-time">Loading...</span></div>
+    <div id="predicted-departure">
+        Predicted next departure time: <span id="prediction-time">Loading...</span>
+        <span id="source-context" class="sr-only"></span>
+    </div>
     
     <div class="card">
         <h2>Next Scheduled Times</h2>
@@ -97,9 +119,12 @@
         function displayScheduledTimes() {
             const scheduledDiv = document.getElementById('scheduled-times');
             const nextTimes = getNextScheduledTimes();
-            scheduledDiv.innerHTML = nextTimes.length > 0 
-                ? nextTimes.map(t => `${t.hour.toString().padStart(2,'0')}:${t.minute.toString().padStart(2,'0')}`).join('<br>')
-                : 'No more scheduled departures today';
+            if (nextTimes.length > 0) {
+                const listItems = nextTimes.map(t => `<li>${t.hour.toString().padStart(2,'0')}:${t.minute.toString().padStart(2,'0')}</li>`).join('');
+                scheduledDiv.innerHTML = `<ul style="list-style: none; padding: 0; margin: 0;">${listItems}</ul>`;
+            } else {
+                scheduledDiv.textContent = 'No more scheduled departures today';
+            }
         }
 
         async function fetchLiveData(endpoint) {
@@ -116,18 +141,21 @@
         async function fetchPrediction() {
             const data = await fetchLiveData('/api/times/CHI/2');
             const predictionSpan = document.getElementById('prediction-time');
+            const sourceContext = document.getElementById('source-context');
             
             if (data && data.length > 0) {
                 const now = new Date();
                 const predictedTime = new Date(now.getTime() + (data[0].dueIn - 2) * 60000);
                 predictionSpan.textContent = `${predictedTime.getHours().toString().padStart(2,'0')}:${predictedTime.getMinutes().toString().padStart(2,'0')}`;
-                predictionSpan.parentElement.style.background = '#27ae60'; // Green when live
+                predictionSpan.parentElement.style.background = '#1b5e20'; // Green when live
+                sourceContext.textContent = '(Live prediction)';
             } else {
                 const nextTimes = getNextScheduledTimes();
                 predictionSpan.textContent = nextTimes.length > 0 
                     ? `${nextTimes[0].hour.toString().padStart(2,'0')}:${nextTimes[0].minute.toString().padStart(2,'0')}`
                     : 'No departures';
-                predictionSpan.parentElement.style.background = '#3498db'; // Blue when static
+                predictionSpan.parentElement.style.background = '#1565c0'; // Blue when static
+                sourceContext.textContent = '(Scheduled time)';
             }
         }
 
@@ -138,14 +166,26 @@
             const statusIndicator = document.getElementById('statusIndicator');
             const timestampDiv = document.getElementById('analysisTimestamp');
 
+            statusIndicator.setAttribute('role', 'img');
+
             if (nextScheduled.length === 0) {
                 analysisContent.textContent = 'Service has ended for the day.';
                 statusIndicator.className = 'status-indicator status-info';
+                statusIndicator.setAttribute('aria-label', 'Status: Info');
             } else {
                 const next = nextScheduled[0];
                 const minsUntil = next.hour * 60 + next.minute - (now.getHours() * 60 + now.getMinutes());
-                analysisContent.textContent = `${next.hour.toString().padStart(2,'0')}:${next.minute.toString().padStart(2,'0')} (${minsUntil} mins)`;
-                statusIndicator.className = 'status-indicator status-info';
+
+                let timeText;
+                if (minsUntil === 0) {
+                    timeText = 'Due now';
+                } else {
+                    timeText = `${minsUntil} ${minsUntil === 1 ? 'min' : 'mins'}`;
+                }
+
+                analysisContent.textContent = `${next.hour.toString().padStart(2,'0')}:${next.minute.toString().padStart(2,'0')} (${timeText})`;
+                statusIndicator.className = 'status-indicator status-good';
+                statusIndicator.setAttribute('aria-label', 'Status: Good');
             }
             
             timestampDiv.textContent = `Updated: ${now.toLocaleTimeString('en-GB')}`;
@@ -153,11 +193,24 @@
 
         // Load everything
         async function updateAll() {
-            displayScheduledTimes();
-            await fetchPrediction();
-            analyzeService();
+            const refreshBtn = document.getElementById('refresh-btn');
+            if (refreshBtn) {
+                refreshBtn.disabled = true;
+                refreshBtn.textContent = 'Refreshing...';
+            }
+            try {
+                displayScheduledTimes();
+                await fetchPrediction();
+                analyzeService();
+            } finally {
+                if (refreshBtn) {
+                    refreshBtn.disabled = false;
+                    refreshBtn.textContent = 'Refresh';
+                }
+            }
         }
         
+        document.getElementById('refresh-btn').addEventListener('click', updateAll);
         updateAll();
         setInterval(updateAll, 15000);
     </script>


### PR DESCRIPTION
💡 What: Improved accessibility and added a manual refresh button.
🎯 Why: The previous colors had low contrast, and the lack of semantic lists made it harder for screen reader users. The manual refresh button provides users with immediate feedback and control.
📸 Before/After: Colors are now darker (#1565c0 blue, #1b5e20 green), and a new Refresh button is centered below the header.
♿ Accessibility: Added ARIA roles/labels, semantic lists, and screen reader-only text for data source context.

---
*PR created automatically by Jules for task [14030367475649387376](https://jules.google.com/task/14030367475649387376) started by @ColinPattinson*