### PR TITLE
🎨 Palette: Improve accessibility and contrast of prediction display

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-05-15 - Screen Reader Context for Color-Coded States
+**Learning:** The application used background colors (blue vs green) to distinguish between scheduled and live data, which is inaccessible to screen reader users and users with color blindness. Standard status colors like #27ae60 and #3498db also failed WCAG AA contrast requirements with white text.
+**Action:** Always pair color changes with visually hidden textual descriptions (`.sr-only`) and ensure background colors meet a minimum 4.5:1 contrast ratio (WCAG AA) or 7:1 (WCAG AAA) for maximum accessibility. Use CSS classes and transitions for state changes instead of direct JS style manipulation.

--- a/index.html
+++ b/index.html
@@ -7,8 +7,12 @@
     <style>
         body { font-family: Arial, sans-serif; margin: 20px; }
         #predicted-departure {
-            background: #3498db; color: white; padding: 20px; border-radius: 8px; 
+            background: #1565c0; color: white; padding: 20px; border-radius: 8px;
             margin: 20px 0; font-size: 2em; text-align: center;
+            transition: background-color 0.3s ease;
+        }
+        #predicted-departure.is-live {
+            background: #1b5e20;
         }
         .card { 
             background: #f5f5f5; padding: 20px; border-radius: 8px; margin: 20px 0;
@@ -35,12 +39,26 @@
             padding: 16px; margin-top: 20px; font-size: 0.95em; color: #856404; 
             text-align: center;
         }
+        .sr-only {
+            position: absolute;
+            width: 1px;
+            height: 1px;
+            padding: 0;
+            margin: -1px;
+            overflow: hidden;
+            clip: rect(0, 0, 0, 0);
+            white-space: nowrap;
+            border-width: 0;
+        }
     </style>
 </head>
 <body>
     <h1 style="text-align: center;">South Shields Metro Departures</h1>
     
-    <div id="predicted-departure">Predicted next departure time: <span id="prediction-time">Loading...</span></div>
+    <div id="predicted-departure" aria-live="polite">
+        Predicted next departure time: <span id="prediction-time">Loading...</span>
+        <span id="prediction-source" class="sr-only"></span>
+    </div>
     
     <div class="card">
         <h2>Next Scheduled Times</h2>
@@ -116,18 +134,21 @@
         async function fetchPrediction() {
             const data = await fetchLiveData('/api/times/CHI/2');
             const predictionSpan = document.getElementById('prediction-time');
+            const sourceSpan = document.getElementById('prediction-source');
             
             if (data && data.length > 0) {
                 const now = new Date();
                 const predictedTime = new Date(now.getTime() + (data[0].dueIn - 2) * 60000);
                 predictionSpan.textContent = `${predictedTime.getHours().toString().padStart(2,'0')}:${predictedTime.getMinutes().toString().padStart(2,'0')}`;
-                predictionSpan.parentElement.style.background = '#27ae60'; // Green when live
+                predictionSpan.parentElement.classList.add('is-live');
+                sourceSpan.textContent = '(Live prediction)';
             } else {
                 const nextTimes = getNextScheduledTimes();
                 predictionSpan.textContent = nextTimes.length > 0 
                     ? `${nextTimes[0].hour.toString().padStart(2,'0')}:${nextTimes[0].minute.toString().padStart(2,'0')}`
                     : 'No departures';
-                predictionSpan.parentElement.style.background = '#3498db'; // Blue when static
+                predictionSpan.parentElement.classList.remove('is-live');
+                sourceSpan.textContent = '(Scheduled time)';
             }
         }
 


### PR DESCRIPTION
### 💡 What:
Improved the accessibility and visual feedback of the next departure prediction display.

### 🎯 Why:
The original design used color alone to distinguish between live and scheduled data, which is inaccessible to many users. Additionally, the original colors failed WCAG AA contrast requirements when paired with white text.

### 📸 Before/After:
- **Before**: Light blue (#3498db) or green (#27ae60) backgrounds with low contrast. No screen reader context for data source.
- **After**: High-contrast blue (#1565c0) and green (#1b5e20) backgrounds. Smooth transition between states. Screen readers now announce updates and the data source (Live vs. Scheduled).

### ♿ Accessibility:
- Background colors now meet WCAG AA contrast standards (>= 4.5:1).
- Added `aria-live="polite"` to the prediction container.
- Added a `.sr-only` span to provide textual context for the data source.

---
*PR created automatically by Jules for task [8199333690699872159](https://jules.google.com/task/8199333690699872159) started by @ColinPattinson*