### PR TITLE
🎨 Palette: Accessibility and semantic improvements for departure times

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-04-22 - [Accessible Contrast and Semantic Lists]
+**Learning:** Standard status colors like #27ae60 (green) and #3498db (blue) may pass visual check but fail WCAG AA contrast requirements when background and foreground colors are not carefully paired. Also, using `<ul>` and `<li>` for lists of times provides better context for screen readers compared to `<br>` separated strings.
+**Action:** Always verify contrast ratios when changing background colors and prefer semantic list elements for repeating data items.

--- a/index.html
+++ b/index.html
@@ -35,12 +35,31 @@
             padding: 16px; margin-top: 20px; font-size: 0.95em; color: #856404; 
             text-align: center;
         }
+        .sr-only {
+            position: absolute;
+            width: 1px;
+            height: 1px;
+            padding: 0;
+            margin: -1px;
+            overflow: hidden;
+            clip: rect(0, 0, 0, 0);
+            white-space: nowrap;
+            border-width: 0;
+        }
+        #scheduled-times ul {
+            list-style: none;
+            padding: 0;
+            margin: 0;
+        }
     </style>
 </head>
 <body>
     <h1 style="text-align: center;">South Shields Metro Departures</h1>
     
-    <div id="predicted-departure">Predicted next departure time: <span id="prediction-time">Loading...</span></div>
+    <div id="predicted-departure" aria-live="polite">
+        <span id="prediction-source" class="sr-only"></span>
+        Predicted next departure time: <span id="prediction-time">Loading...</span>
+    </div>
     
     <div class="card">
         <h2>Next Scheduled Times</h2>
@@ -98,7 +117,7 @@
             const scheduledDiv = document.getElementById('scheduled-times');
             const nextTimes = getNextScheduledTimes();
             scheduledDiv.innerHTML = nextTimes.length > 0 
-                ? nextTimes.map(t => `${t.hour.toString().padStart(2,'0')}:${t.minute.toString().padStart(2,'0')}`).join('<br>')
+                ? `<ul>${nextTimes.map(t => `<li>${t.hour.toString().padStart(2,'0')}:${t.minute.toString().padStart(2,'0')}</li>`).join('')}</ul>`
                 : 'No more scheduled departures today';
         }
 
@@ -116,18 +135,23 @@
         async function fetchPrediction() {
             const data = await fetchLiveData('/api/times/CHI/2');
             const predictionSpan = document.getElementById('prediction-time');
+            const sourceSpan = document.getElementById('prediction-source');
             
             if (data && data.length > 0) {
                 const now = new Date();
                 const predictedTime = new Date(now.getTime() + (data[0].dueIn - 2) * 60000);
                 predictionSpan.textContent = `${predictedTime.getHours().toString().padStart(2,'0')}:${predictedTime.getMinutes().toString().padStart(2,'0')}`;
-                predictionSpan.parentElement.style.background = '#27ae60'; // Green when live
+                predictionSpan.parentElement.style.background = '#1b5e20'; // Accessible green when live
+                predictionSpan.parentElement.style.color = 'white';
+                sourceSpan.textContent = 'Live prediction: ';
             } else {
                 const nextTimes = getNextScheduledTimes();
                 predictionSpan.textContent = nextTimes.length > 0 
                     ? `${nextTimes[0].hour.toString().padStart(2,'0')}:${nextTimes[0].minute.toString().padStart(2,'0')}`
                     : 'No departures';
-                predictionSpan.parentElement.style.background = '#3498db'; // Blue when static
+                predictionSpan.parentElement.style.background = '#1565c0'; // Accessible blue when static
+                predictionSpan.parentElement.style.color = 'white';
+                sourceSpan.textContent = 'Scheduled fallback: ';
             }
         }
 
@@ -144,7 +168,7 @@
             } else {
                 const next = nextScheduled[0];
                 const minsUntil = next.hour * 60 + next.minute - (now.getHours() * 60 + now.getMinutes());
-                analysisContent.textContent = `${next.hour.toString().padStart(2,'0')}:${next.minute.toString().padStart(2,'0')} (${minsUntil} mins)`;
+                analysisContent.textContent = `${next.hour.toString().padStart(2,'0')}:${next.minute.toString().padStart(2,'0')} (${minsUntil} ${minsUntil === 1 ? 'min' : 'mins'})`;
                 statusIndicator.className = 'status-indicator status-info';
             }
             


### PR DESCRIPTION
💡 What: This enhancement improves the accessibility and semantics of the metro departure displays. It refactors the scheduled times list into a semantic `<ul>`, adds `aria-live` and visually hidden status labels (`.sr-only`) to the prediction bar, updates background colors to WCAG AA-compliant shades with explicit white text for contrast, and fixes a minor pluralization bug in the countdown display.

🎯 Why: These changes ensure that users relying on assistive technologies receive the same information as sighted users (specifically whether a time is live or scheduled) and can navigate the list of times more easily. The improved contrast and fixed pluralization provide a more polished and professional experience for everyone.

📸 Before/After: Visual changes include more accessible (darker) green/blue backgrounds for the prediction bar and better-spaced list items for scheduled times.

♿ Accessibility:
- Added `aria-live="polite"` for dynamic updates.
- Used `.sr-only` for "Live prediction" vs "Scheduled fallback" labels.
- Implemented WCAG AA-compliant contrast ratios.
- Used semantic `<ul>` and `<li>` for lists of times.

---
*PR created automatically by Jules for task [2281440633880716138](https://jules.google.com/task/2281440633880716138) started by @ColinPattinson*