### PR TITLE
🎨 Palette: Improved departure countdown clarity

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-04-29 - Accessible Transit Countdowns
+**Learning:** For time-sensitive transit applications, "Due now" provides better UX than "0 mins". Additionally, using aria-live="polite" on parent containers ensures that screen readers announce both the label and the dynamic update together, providing necessary context.
+**Action:** Always implement a "Due now" state for 0-minute countdowns and prefer aria-live on context-rich parent elements rather than just the dynamic value span.

--- a/index.html
+++ b/index.html
@@ -81,7 +81,7 @@
             const schedule = getScheduleForDay();
             let upcomingTimes = [];
             if (schedule[currentHour]) {
-                const validMinutes = schedule[currentHour].filter(m => m > currentMinute);
+                const validMinutes = schedule[currentHour].filter(m => m >= currentMinute);
                 upcomingTimes.push(...validMinutes.map(m => ({hour: currentHour, minute: m})));
             }
             let hour = currentHour + 1;
@@ -144,7 +144,8 @@
             } else {
                 const next = nextScheduled[0];
                 const minsUntil = next.hour * 60 + next.minute - (now.getHours() * 60 + now.getMinutes());
-                analysisContent.textContent = `${next.hour.toString().padStart(2,'0')}:${next.minute.toString().padStart(2,'0')} (${minsUntil} mins)`;
+                const displayMins = minsUntil === 0 ? 'Due now' : `${minsUntil} ${minsUntil === 1 ? 'min' : 'mins'}`;
+                analysisContent.textContent = `${next.hour.toString().padStart(2,'0')}:${next.minute.toString().padStart(2,'0')} (${displayMins})`;
                 statusIndicator.className = 'status-indicator status-info';
             }
             


### PR DESCRIPTION
Refined the departure countdown logic to display 'Due now' for 0-minute wait times and correctly pluralize 'min'/'mins'. Additionally, updated the schedule filter to include the current minute, ensuring immediate departures are properly shown to the user. This makes the interface more intuitive and prevents missing immediate departures.

---
*PR created automatically by Jules for task [4688930763953752307](https://jules.google.com/task/4688930763953752307) started by @ColinPattinson*