### PR TITLE
🎨 Palette: Improve accessibility and departure display clarity

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,7 @@
+## 2025-05-14 - Screen Reader Context Pattern for Color-Coded States
+**Learning:** Visual-only indicators (like background color changes from blue to green) are inaccessible to screen reader users and those with color blindness. Implementing an `.sr-only` span that updates its text (e.g., "(Live)" vs "(Scheduled)") alongside the visual change ensures state parity across all users.
+**Action:** Always pair visual state changes (color, icons) with visually hidden text or ARIA attributes that describe the new state.
+
+## 2025-05-14 - Contrast Ratios in Status Indicators
+**Learning:** The application's default status colors (#27ae60 green and #3498db blue) with white text yield contrast ratios of 2.9:1 and 3.17:1, failing the WCAG AA 4.5:1 requirement for normal text.
+**Action:** In future updates, propose higher-contrast color pairs or use dark text on light backgrounds for status badges to meet accessibility standards.

--- a/index.html
+++ b/index.html
@@ -35,12 +35,19 @@
             padding: 16px; margin-top: 20px; font-size: 0.95em; color: #856404; 
             text-align: center;
         }
+        .sr-only {
+            position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px;
+            overflow: hidden; clip: rect(0, 0, 0, 0); white-space: nowrap; border-width: 0;
+        }
     </style>
 </head>
 <body>
     <h1 style="text-align: center;">South Shields Metro Departures</h1>
     
-    <div id="predicted-departure">Predicted next departure time: <span id="prediction-time">Loading...</span></div>
+    <div id="predicted-departure" aria-live="polite">
+        Predicted next departure time: <span id="prediction-time">Loading...</span>
+        <span id="prediction-status" class="sr-only"></span>
+    </div>
     
     <div class="card">
         <h2>Next Scheduled Times</h2>
@@ -49,7 +56,7 @@
     
     <div class="service-analysis">
         <h2><span class="status-indicator status-info" id="statusIndicator"></span>Next scheduled Departure:</h2>
-        <div id="analysisContent" class="analysis-content">Loading...</div>
+        <div id="analysisContent" class="analysis-content" aria-live="polite">Loading...</div>
         <div class="analysis-timestamp" id="analysisTimestamp"></div>
     </div>
     
@@ -81,7 +88,7 @@
             const schedule = getScheduleForDay();
             let upcomingTimes = [];
             if (schedule[currentHour]) {
-                const validMinutes = schedule[currentHour].filter(m => m > currentMinute);
+                const validMinutes = schedule[currentHour].filter(m => m >= currentMinute);
                 upcomingTimes.push(...validMinutes.map(m => ({hour: currentHour, minute: m})));
             }
             let hour = currentHour + 1;
@@ -116,18 +123,21 @@
         async function fetchPrediction() {
             const data = await fetchLiveData('/api/times/CHI/2');
             const predictionSpan = document.getElementById('prediction-time');
+            const predictionStatus = document.getElementById('prediction-status');
             
             if (data && data.length > 0) {
                 const now = new Date();
                 const predictedTime = new Date(now.getTime() + (data[0].dueIn - 2) * 60000);
                 predictionSpan.textContent = `${predictedTime.getHours().toString().padStart(2,'0')}:${predictedTime.getMinutes().toString().padStart(2,'0')}`;
                 predictionSpan.parentElement.style.background = '#27ae60'; // Green when live
+                predictionStatus.textContent = '(Live departure)';
             } else {
                 const nextTimes = getNextScheduledTimes();
                 predictionSpan.textContent = nextTimes.length > 0 
                     ? `${nextTimes[0].hour.toString().padStart(2,'0')}:${nextTimes[0].minute.toString().padStart(2,'0')}`
                     : 'No departures';
                 predictionSpan.parentElement.style.background = '#3498db'; // Blue when static
+                predictionStatus.textContent = '(Scheduled departure)';
             }
         }
 
@@ -144,7 +154,13 @@
             } else {
                 const next = nextScheduled[0];
                 const minsUntil = next.hour * 60 + next.minute - (now.getHours() * 60 + now.getMinutes());
-                analysisContent.textContent = `${next.hour.toString().padStart(2,'0')}:${next.minute.toString().padStart(2,'0')} (${minsUntil} mins)`;
+                let timeText = `${next.hour.toString().padStart(2,'0')}:${next.minute.toString().padStart(2,'0')}`;
+                if (minsUntil === 0) {
+                    timeText += ' (Due now)';
+                } else {
+                    timeText += ` (${minsUntil} ${minsUntil === 1 ? 'min' : 'mins'})`;
+                }
+                analysisContent.textContent = timeText;
                 statusIndicator.className = 'status-indicator status-info';
             }
             


### PR DESCRIPTION
### 💡 What:
Implemented several micro-UX and accessibility enhancements to the Metro Departures dashboard:
- **ARIA Live Regions**: Added `aria-live="polite"` to ensuring dynamic time updates are announced to screen readers.
- **Screen Reader Context**: Added a visually hidden span that explicitly states whether a departure is "(Live departure)" or "(Scheduled departure)", bridging the gap for users who cannot see the color-coded background.
- **Logic Refinement**: Updated schedule filtering to include the current minute (`m >= currentMinute`), preventing immediate departures from disappearing.
- **Micro-Copy**: Added "Due now" for 0-minute countdowns and handled singular/plural pluralization for "min/mins".

### 🎯 Why:
The original interface relied solely on color (blue vs green) to indicate data source, which is inaccessible. Additionally, the countdown logic felt slightly "off" when a train was currently due, and singular minutes used plural labels.

### ♿ Accessibility:
- Corrected color-only state communication using the Screen Reader Context Pattern.
- Added ARIA live regions for dynamic content.
- Verified that all text remains readable, though noted future improvements for color contrast.

---
*PR created automatically by Jules for task [13014576647701950855](https://jules.google.com/task/13014576647701950855) started by @ColinPattinson*