### PR TITLE
🎨 Palette: Enhance departure accessibility and intuitive feedback

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-05-12 - Screen Reader Context Pattern
+**Learning:** For dynamic UI components that change background color to signify state (e.g., Live vs. Scheduled), visual users get immediate feedback, but screen reader users miss this. Using a visually hidden `sr-only` span that updates its text alongside the visual change provides the necessary context.
+**Action:** Always pair visual state changes with a screen-reader-only text update or appropriate ARIA attributes.

--- a/index.html
+++ b/index.html
@@ -35,12 +35,24 @@
             padding: 16px; margin-top: 20px; font-size: 0.95em; color: #856404; 
             text-align: center;
         }
+        .sr-only {
+            position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px;
+            overflow: hidden; clip: rect(0, 0, 0, 0); white-space: nowrap; border-width: 0;
+        }
     </style>
 </head>
 <body>
-    <h1 style="text-align: center;">South Shields Metro Departures</h1>
+    <h1 style="text-align: center;">
+        South Shields Metro Departures
+        <button id="refresh-btn" aria-label="Refresh departures" title="Refresh departures" style="background: none; border: none; cursor: pointer; font-size: 0.6em; vertical-align: middle; color: #2c3e50; padding: 5px;">
+            ↻
+        </button>
+    </h1>
     
-    <div id="predicted-departure">Predicted next departure time: <span id="prediction-time">Loading...</span></div>
+    <div id="predicted-departure" aria-live="polite">
+        <span class="sr-only" id="prediction-status"></span>
+        Predicted next departure time: <span id="prediction-time">Loading...</span>
+    </div>
     
     <div class="card">
         <h2>Next Scheduled Times</h2>
@@ -81,7 +93,7 @@
             const schedule = getScheduleForDay();
             let upcomingTimes = [];
             if (schedule[currentHour]) {
-                const validMinutes = schedule[currentHour].filter(m => m > currentMinute);
+                const validMinutes = schedule[currentHour].filter(m => m >= currentMinute);
                 upcomingTimes.push(...validMinutes.map(m => ({hour: currentHour, minute: m})));
             }
             let hour = currentHour + 1;
@@ -116,18 +128,21 @@
         async function fetchPrediction() {
             const data = await fetchLiveData('/api/times/CHI/2');
             const predictionSpan = document.getElementById('prediction-time');
+            const predictionStatus = document.getElementById('prediction-status');
             
             if (data && data.length > 0) {
                 const now = new Date();
                 const predictedTime = new Date(now.getTime() + (data[0].dueIn - 2) * 60000);
                 predictionSpan.textContent = `${predictedTime.getHours().toString().padStart(2,'0')}:${predictedTime.getMinutes().toString().padStart(2,'0')}`;
                 predictionSpan.parentElement.style.background = '#27ae60'; // Green when live
+                predictionStatus.textContent = 'Live prediction: ';
             } else {
                 const nextTimes = getNextScheduledTimes();
                 predictionSpan.textContent = nextTimes.length > 0 
                     ? `${nextTimes[0].hour.toString().padStart(2,'0')}:${nextTimes[0].minute.toString().padStart(2,'0')}`
                     : 'No departures';
                 predictionSpan.parentElement.style.background = '#3498db'; // Blue when static
+                predictionStatus.textContent = 'Scheduled time: ';
             }
         }
 
@@ -143,8 +158,11 @@
                 statusIndicator.className = 'status-indicator status-info';
             } else {
                 const next = nextScheduled[0];
-                const minsUntil = next.hour * 60 + next.minute - (now.getHours() * 60 + now.getMinutes());
-                analysisContent.textContent = `${next.hour.toString().padStart(2,'0')}:${next.minute.toString().padStart(2,'0')} (${minsUntil} mins)`;
+                let minsUntil = next.hour * 60 + next.minute - (now.getHours() * 60 + now.getMinutes());
+                if (minsUntil < 0) minsUntil += 1440; // Handle midnight wrap-around
+                const timeStr = `${next.hour.toString().padStart(2,'0')}:${next.minute.toString().padStart(2,'0')}`;
+                const relativeStr = minsUntil === 0 ? 'Due now' : `(${minsUntil} ${minsUntil === 1 ? 'min' : 'mins'})`;
+                analysisContent.textContent = `${timeStr} ${relativeStr}`;
                 statusIndicator.className = 'status-indicator status-info';
             }
             
@@ -153,11 +171,25 @@
 
         // Load everything
         async function updateAll() {
-            displayScheduledTimes();
-            await fetchPrediction();
-            analyzeService();
+            const refreshBtn = document.getElementById('refresh-btn');
+            if (refreshBtn) {
+                refreshBtn.disabled = true;
+                refreshBtn.style.opacity = '0.5';
+            }
+            try {
+                displayScheduledTimes();
+                await fetchPrediction();
+                analyzeService();
+            } finally {
+                if (refreshBtn) {
+                    refreshBtn.disabled = false;
+                    refreshBtn.style.opacity = '1';
+                }
+            }
         }
         
+        document.getElementById('refresh-btn').addEventListener('click', updateAll);
+
         updateAll();
         setInterval(updateAll, 15000);
     </script>


### PR DESCRIPTION
### 🎨 Palette: Enhance departure accessibility and intuitive feedback

#### 💡 What:
Implemented several micro-UX and accessibility improvements to the Metro departures interface, including a manual refresh button, "Due now" status for imminent trains, and improved screen reader support.

#### 🎯 Why:
- Users needed a way to manually trigger updates for real-time data.
- "0 mins" is less intuitive than "Due now" for transit departures.
- Visual status indicators (background colors) were inaccessible to screen reader users.
- Imminent departures were being prematurely removed from the scheduled list due to strict greater-than filtering.

#### 📸 Before/After:
- **Before:** Static time display, no refresh button, "(0 mins)" for immediate departures, no screen reader context for live vs scheduled states.
- **After:** Refresh button (↻) with loading state, "Due now" text, "Live prediction" or "Scheduled time" announced to screen readers.

#### ♿ Accessibility:
- Added `aria-live="polite"` to the predicted departure container.
- Implemented the 'Screen Reader Context Pattern' using `.sr-only` spans to communicate state.
- Added `aria-label` and `title` to the new manual refresh button.
- Ensured the refresh button remains keyboard accessible.

---
*PR created automatically by Jules for task [13974611442557648002](https://jules.google.com/task/13974611442557648002) started by @ColinPattinson*