### PR TITLE
🎨 Palette: Enhanced countdowns and manual refresh

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-05-14 - Micro-UX improvements for countdowns and refresh states
+**Learning:** Users find "Due now" more intuitive than "0 mins" for imminent departures. Consistent pluralization (1 min vs 2 mins) and visual feedback on manual refresh actions (loading states) significantly improve the perceived quality of the interface. Accessibility should be baked in using aria-live for dynamic updates and sr-only labels for color-coded status indicators.
+**Action:** Always check for singular/plural logic in countdowns and ensure interactive elements provide immediate state feedback.

--- a/index.html
+++ b/index.html
@@ -35,12 +35,22 @@
             padding: 16px; margin-top: 20px; font-size: 0.95em; color: #856404; 
             text-align: center;
         }
+        .sr-only {
+            position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px;
+            overflow: hidden; clip: rect(0,0,0,0); white-space: nowrap; border: 0;
+        }
     </style>
 </head>
 <body>
     <h1 style="text-align: center;">South Shields Metro Departures</h1>
     
-    <div id="predicted-departure">Predicted next departure time: <span id="prediction-time">Loading...</span></div>
+    <div id="predicted-departure" aria-live="polite">Predicted next departure time: <span id="prediction-time">Loading...</span></div>
+
+    <div style="text-align: center; margin-bottom: 20px;">
+        <button id="refresh-btn" style="padding: 10px 20px; font-size: 1em; cursor: pointer; border-radius: 4px; border: 1px solid #ccc; background: #fff;">
+            Refresh Data
+        </button>
+    </div>
     
     <div class="card">
         <h2>Next Scheduled Times</h2>
@@ -48,7 +58,11 @@
     </div>
     
     <div class="service-analysis">
-        <h2><span class="status-indicator status-info" id="statusIndicator"></span>Next scheduled Departure:</h2>
+        <h2>
+            <span class="status-indicator status-info" id="statusIndicator"></span>
+            <span id="statusText" class="sr-only">Scheduled</span>
+            Next scheduled Departure:
+        </h2>
         <div id="analysisContent" class="analysis-content">Loading...</div>
         <div class="analysis-timestamp" id="analysisTimestamp"></div>
     </div>
@@ -81,7 +95,7 @@
             const schedule = getScheduleForDay();
             let upcomingTimes = [];
             if (schedule[currentHour]) {
-                const validMinutes = schedule[currentHour].filter(m => m > currentMinute);
+                const validMinutes = schedule[currentHour].filter(m => m >= currentMinute);
                 upcomingTimes.push(...validMinutes.map(m => ({hour: currentHour, minute: m})));
             }
             let hour = currentHour + 1;
@@ -117,17 +131,20 @@
             const data = await fetchLiveData('/api/times/CHI/2');
             const predictionSpan = document.getElementById('prediction-time');
             
+            const statusText = document.getElementById('statusText');
             if (data && data.length > 0) {
                 const now = new Date();
                 const predictedTime = new Date(now.getTime() + (data[0].dueIn - 2) * 60000);
                 predictionSpan.textContent = `${predictedTime.getHours().toString().padStart(2,'0')}:${predictedTime.getMinutes().toString().padStart(2,'0')}`;
                 predictionSpan.parentElement.style.background = '#27ae60'; // Green when live
+                if (statusText) statusText.textContent = 'Live';
             } else {
                 const nextTimes = getNextScheduledTimes();
                 predictionSpan.textContent = nextTimes.length > 0 
                     ? `${nextTimes[0].hour.toString().padStart(2,'0')}:${nextTimes[0].minute.toString().padStart(2,'0')}`
                     : 'No departures';
                 predictionSpan.parentElement.style.background = '#3498db'; // Blue when static
+                if (statusText) statusText.textContent = 'Scheduled';
             }
         }
 
@@ -143,8 +160,18 @@
                 statusIndicator.className = 'status-indicator status-info';
             } else {
                 const next = nextScheduled[0];
-                const minsUntil = next.hour * 60 + next.minute - (now.getHours() * 60 + now.getMinutes());
-                analysisContent.textContent = `${next.hour.toString().padStart(2,'0')}:${next.minute.toString().padStart(2,'0')} (${minsUntil} mins)`;
+                let minsUntil = (next.hour * 60 + next.minute) - (now.getHours() * 60 + now.getMinutes());
+                if (minsUntil < 0) minsUntil += 1440; // Handle midnight wrap
+
+                const timeStr = `${next.hour.toString().padStart(2,'0')}:${next.minute.toString().padStart(2,'0')}`;
+                let countdownStr = '';
+                if (minsUntil === 0) {
+                    countdownStr = '(Due now)';
+                } else {
+                    countdownStr = `(${minsUntil} ${minsUntil === 1 ? 'min' : 'mins'})`;
+                }
+
+                analysisContent.textContent = `${timeStr} ${countdownStr}`;
                 statusIndicator.className = 'status-indicator status-info';
             }
             
@@ -153,11 +180,25 @@
 
         // Load everything
         async function updateAll() {
-            displayScheduledTimes();
-            await fetchPrediction();
-            analyzeService();
+            const refreshBtn = document.getElementById('refresh-btn');
+            if (refreshBtn) {
+                refreshBtn.disabled = true;
+                refreshBtn.textContent = 'Updating...';
+            }
+            try {
+                displayScheduledTimes();
+                await fetchPrediction();
+                analyzeService();
+            } finally {
+                if (refreshBtn) {
+                    refreshBtn.disabled = false;
+                    refreshBtn.textContent = 'Refresh Data';
+                }
+            }
         }
         
+        document.getElementById('refresh-btn').addEventListener('click', updateAll);
+
         updateAll();
         setInterval(updateAll, 15000);
     </script>


### PR DESCRIPTION
💡 What: Enhanced the departure board with "Due now" labels for imminent trains, fixed minute pluralization (1 min vs 2 mins), and added a manual "Refresh Data" button with a visual loading state.

🎯 Why: These changes make the interface feel more responsive and intuitive. "Due now" is a standard transit pattern that reduces cognitive load, and the refresh button provides users with agency and confirmation of data freshness.

📸 Before/After: Imminent departures now show "(Due now)" instead of "(0 mins)". A new "Refresh Data" button is available below the main prediction.

♿ Accessibility: Implemented `aria-live="polite"` on the main prediction container to ensure updates are announced. Added a visually hidden `.sr-only` status text that updates between "Live" and "Scheduled" to accompany the color-coded indicator dot.

---
*PR created automatically by Jules for task [7326448059563842018](https://jules.google.com/task/7326448059563842018) started by @ColinPattinson*