### PR TITLE
🎨 Palette: Accessibility and Micro-UX Enhancements

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-05-03 - Screen Reader Context Pattern
+**Learning:** Purely color-coded state transitions (like blue for scheduled vs green for live) are invisible to screen readers and color-blind users. Using a visually hidden utility class to update text labels in sync with color changes provides essential context without cluttering the visual UI.
+**Action:** Always include a hidden status span when using color to indicate state, and update its text content whenever the color changes.

--- a/index.html
+++ b/index.html
@@ -35,12 +35,23 @@
             padding: 16px; margin-top: 20px; font-size: 0.95em; color: #856404; 
             text-align: center;
         }
+        .sr-only {
+            position: absolute;
+            width: 1px;
+            height: 1px;
+            padding: 0;
+            margin: -1px;
+            overflow: hidden;
+            clip: rect(0, 0, 0, 0);
+            white-space: nowrap;
+            border-width: 0;
+        }
     </style>
 </head>
 <body>
     <h1 style="text-align: center;">South Shields Metro Departures</h1>
     
-    <div id="predicted-departure">Predicted next departure time: <span id="prediction-time">Loading...</span></div>
+    <div id="predicted-departure">Predicted next departure time: <span id="prediction-time">Loading...</span> <span id="status-label" class="sr-only"></span></div>
     
     <div class="card">
         <h2>Next Scheduled Times</h2>
@@ -48,7 +59,7 @@
     </div>
     
     <div class="service-analysis">
-        <h2><span class="status-indicator status-info" id="statusIndicator"></span>Next scheduled Departure:</h2>
+        <h2><span class="status-indicator status-info" id="statusIndicator"></span><span id="indicator-text" class="sr-only"></span>Next scheduled Departure:</h2>
         <div id="analysisContent" class="analysis-content">Loading...</div>
         <div class="analysis-timestamp" id="analysisTimestamp"></div>
     </div>
@@ -81,7 +92,7 @@
             const schedule = getScheduleForDay();
             let upcomingTimes = [];
             if (schedule[currentHour]) {
-                const validMinutes = schedule[currentHour].filter(m => m > currentMinute);
+                const validMinutes = schedule[currentHour].filter(m => m >= currentMinute);
                 upcomingTimes.push(...validMinutes.map(m => ({hour: currentHour, minute: m})));
             }
             let hour = currentHour + 1;
@@ -116,18 +127,21 @@
         async function fetchPrediction() {
             const data = await fetchLiveData('/api/times/CHI/2');
             const predictionSpan = document.getElementById('prediction-time');
+            const statusLabel = document.getElementById('status-label');
             
             if (data && data.length > 0) {
                 const now = new Date();
                 const predictedTime = new Date(now.getTime() + (data[0].dueIn - 2) * 60000);
                 predictionSpan.textContent = `${predictedTime.getHours().toString().padStart(2,'0')}:${predictedTime.getMinutes().toString().padStart(2,'0')}`;
                 predictionSpan.parentElement.style.background = '#27ae60'; // Green when live
+                statusLabel.textContent = '(Live)';
             } else {
                 const nextTimes = getNextScheduledTimes();
                 predictionSpan.textContent = nextTimes.length > 0 
                     ? `${nextTimes[0].hour.toString().padStart(2,'0')}:${nextTimes[0].minute.toString().padStart(2,'0')}`
                     : 'No departures';
                 predictionSpan.parentElement.style.background = '#3498db'; // Blue when static
+                statusLabel.textContent = '(Scheduled)';
             }
         }
 
@@ -136,16 +150,22 @@
             const nextScheduled = getNextScheduledTimes();
             const analysisContent = document.getElementById('analysisContent');
             const statusIndicator = document.getElementById('statusIndicator');
+            const indicatorText = document.getElementById('indicator-text');
             const timestampDiv = document.getElementById('analysisTimestamp');
 
             if (nextScheduled.length === 0) {
                 analysisContent.textContent = 'Service has ended for the day.';
                 statusIndicator.className = 'status-indicator status-info';
+                indicatorText.textContent = 'Status: Service ended';
             } else {
                 const next = nextScheduled[0];
-                const minsUntil = next.hour * 60 + next.minute - (now.getHours() * 60 + now.getMinutes());
-                analysisContent.textContent = `${next.hour.toString().padStart(2,'0')}:${next.minute.toString().padStart(2,'0')} (${minsUntil} mins)`;
+                let minsUntil = next.hour * 60 + next.minute - (now.getHours() * 60 + now.getMinutes());
+                if (minsUntil < 0) minsUntil += 1440; // Handle midnight wrap
+                const timeStr = `${next.hour.toString().padStart(2,'0')}:${next.minute.toString().padStart(2,'0')}`;
+                const relativeStr = minsUntil === 0 ? 'Due now' : `${minsUntil} mins`;
+                analysisContent.textContent = `${timeStr} (${relativeStr})`;
                 statusIndicator.className = 'status-indicator status-info';
+                indicatorText.textContent = 'Status: Normal';
             }
             
             timestampDiv.textContent = `Updated: ${now.toLocaleTimeString('en-GB')}`;


### PR DESCRIPTION
💡 What: Added accessibility labels and polished the departure countdown.
🎯 Why: Color-coded status was inaccessible to screen readers. "0 mins" was less intuitive than "Due now".
📸 Before/After: The countdown now shows "Due now" when 0 minutes remain, and screen readers receive status updates via hidden labels.
♿ Accessibility: Added sr-only labels for live/scheduled status and service health to support assistive technologies.

---
*PR created automatically by Jules for task [3586907793609588248](https://jules.google.com/task/3586907793609588248) started by @ColinPattinson*