### PR TITLE
🎨 Palette: Add manual refresh and improve accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,7 @@
+## 2026-05-04 - Screen Reader Context Pattern for State-based Styles
+**Learning:** When using background colors (e.g., green/blue) to indicate state (Live/Scheduled), screen reader users miss this info. Adding a visually hidden `.sr-only` span that updates alongside the color ensures parity.
+**Action:** Always pair visual color changes for state with a `.sr-only` label or ARIA attribute.
+
+## 2026-05-04 - Transit Countdown "Due now" Clarity
+**Learning:** Displaying "0 mins" for immediate departures is technically correct but less intuitive than "Due now".
+**Action:** Implement conditional logic to display "Due now" when the countdown reaches zero.

--- a/index.html
+++ b/index.html
@@ -35,12 +35,28 @@
             padding: 16px; margin-top: 20px; font-size: 0.95em; color: #856404; 
             text-align: center;
         }
+        .sr-only {
+            position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px;
+            overflow: hidden; clip: rect(0,0,0,0); border: 0;
+        }
+        #refresh-btn {
+            display: block; margin: 10px auto; padding: 8px 16px;
+            background: #2c3e50; color: white; border: none; border-radius: 4px;
+            cursor: pointer; font-size: 0.9em; transition: background 0.2s;
+        }
+        #refresh-btn:hover { background: #34495e; }
+        #refresh-btn:disabled { background: #95a5a6; cursor: not-allowed; }
     </style>
 </head>
 <body>
     <h1 style="text-align: center;">South Shields Metro Departures</h1>
+
+    <button id="refresh-btn" aria-label="Refresh departure times">Refresh Times</button>
     
-    <div id="predicted-departure">Predicted next departure time: <span id="prediction-time">Loading...</span></div>
+    <div id="predicted-departure" aria-live="polite">
+        <span class="sr-only" id="status-label">Scheduled</span>
+        Predicted next departure time: <span id="prediction-time">Loading...</span>
+    </div>
     
     <div class="card">
         <h2>Next Scheduled Times</h2>
@@ -49,7 +65,7 @@
     
     <div class="service-analysis">
         <h2><span class="status-indicator status-info" id="statusIndicator"></span>Next scheduled Departure:</h2>
-        <div id="analysisContent" class="analysis-content">Loading...</div>
+        <div id="analysisContent" class="analysis-content" aria-live="polite">Loading...</div>
         <div class="analysis-timestamp" id="analysisTimestamp"></div>
     </div>
     
@@ -81,15 +97,14 @@
             const schedule = getScheduleForDay();
             let upcomingTimes = [];
             if (schedule[currentHour]) {
-                const validMinutes = schedule[currentHour].filter(m => m > currentMinute);
+                const validMinutes = schedule[currentHour].filter(m => m >= currentMinute);
                 upcomingTimes.push(...validMinutes.map(m => ({hour: currentHour, minute: m})));
             }
-            let hour = currentHour + 1;
-            while (upcomingTimes.length < 4 && hour <= 23) {
+            for (let i = 1; i <= 24 && upcomingTimes.length < 4; i++) {
+                let hour = (currentHour + i) % 24;
                 if (schedule[hour]) {
                     upcomingTimes.push(...schedule[hour].map(m => ({hour: hour, minute: m})));
                 }
-                hour++;
             }
             return upcomingTimes.slice(0, 4);
         }
@@ -116,18 +131,21 @@
         async function fetchPrediction() {
             const data = await fetchLiveData('/api/times/CHI/2');
             const predictionSpan = document.getElementById('prediction-time');
+            const statusLabel = document.getElementById('status-label');
             
             if (data && data.length > 0) {
                 const now = new Date();
                 const predictedTime = new Date(now.getTime() + (data[0].dueIn - 2) * 60000);
                 predictionSpan.textContent = `${predictedTime.getHours().toString().padStart(2,'0')}:${predictedTime.getMinutes().toString().padStart(2,'0')}`;
                 predictionSpan.parentElement.style.background = '#27ae60'; // Green when live
+                statusLabel.textContent = 'Live';
             } else {
                 const nextTimes = getNextScheduledTimes();
                 predictionSpan.textContent = nextTimes.length > 0 
                     ? `${nextTimes[0].hour.toString().padStart(2,'0')}:${nextTimes[0].minute.toString().padStart(2,'0')}`
                     : 'No departures';
                 predictionSpan.parentElement.style.background = '#3498db'; // Blue when static
+                statusLabel.textContent = 'Scheduled';
             }
         }
 
@@ -143,13 +161,35 @@
                 statusIndicator.className = 'status-indicator status-info';
             } else {
                 const next = nextScheduled[0];
-                const minsUntil = next.hour * 60 + next.minute - (now.getHours() * 60 + now.getMinutes());
-                analysisContent.textContent = `${next.hour.toString().padStart(2,'0')}:${next.minute.toString().padStart(2,'0')} (${minsUntil} mins)`;
-                statusIndicator.className = 'status-indicator status-info';
+                let minsUntil = (next.hour * 60 + next.minute) - (now.getHours() * 60 + now.getMinutes());
+                if (minsUntil < 0) minsUntil += 1440; // Handle midnight wrap
+
+                const timeStr = `${next.hour.toString().padStart(2,'0')}:${next.minute.toString().padStart(2,'0')}`;
+                if (minsUntil === 0) {
+                    analysisContent.textContent = `${timeStr} (Due now)`;
+                    statusIndicator.className = 'status-indicator status-warning';
+                } else {
+                    analysisContent.textContent = `${timeStr} (${minsUntil} ${minsUntil === 1 ? 'min' : 'mins'})`;
+                    statusIndicator.className = 'status-indicator status-info';
+                }
             }
             
             timestampDiv.textContent = `Updated: ${now.toLocaleTimeString('en-GB')}`;
         }
+
+        async function refreshData() {
+            const btn = document.getElementById('refresh-btn');
+            btn.disabled = true;
+            btn.textContent = 'Refreshing...';
+            try {
+                await updateAll();
+            } finally {
+                btn.disabled = false;
+                btn.textContent = 'Refresh Times';
+            }
+        }
+
+        document.getElementById('refresh-btn').onclick = refreshData;
 
         // Load everything
         async function updateAll() {


### PR DESCRIPTION
💡 **What:** Added a manual refresh button, ARIA live regions, visually hidden status labels, "Due now" text, and pluralization for countdowns. Fixed midnight wrap-around for scheduled departures.

🎯 **Why:** To make the interface more interactive, accessible for screen reader users, and accurate across day boundaries.

📸 **Before/After:** (See attached screenshot in verification)

♿ **Accessibility:** 
- Added `aria-live="polite"` to departure display areas so updates are announced.
- Added a visually hidden status label (Live vs Scheduled) to provide context missing from the color-only indicator.
- Improved button accessibility with descriptive ARIA label.

---
*PR created automatically by Jules for task [15695239991066792896](https://jules.google.com/task/15695239991066792896) started by @ColinPattinson*