### PR TITLE
🎨 Palette: Accessibility and Refresh Enhancement

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,7 @@
+## 2023-10-27 - Screen Reader Context Pattern
+**Learning:** Using color-only cues (like green for live, blue for scheduled) fails accessibility for color-blind and screen-reader users. A visually hidden span (.sr-only) that updates its text alongside visual state changes provides the necessary context for assistive technology without cluttering the UI.
+**Action:** Always pair visual state changes (color, icons) with a visually hidden text description for screen readers.
+
+## 2023-10-27 - Robust Relative Time
+**Learning:** Relative time calculations (like "mins until") often fail at the midnight boundary, resulting in negative values. Simple modulo or conditional wrap-around (adding 1440 mins) ensures consistent behavior for late-night transit services.
+**Action:** Implement midnight wrap-around logic for any time-difference calculations in transit apps.

--- a/index.html
+++ b/index.html
@@ -35,12 +35,21 @@
             padding: 16px; margin-top: 20px; font-size: 0.95em; color: #856404; 
             text-align: center;
         }
+        .sr-only { position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px; overflow: hidden; clip: rect(0,0,0,0); border: 0; }
+        .is-live { background-color: #27ae60 !important; }
+        .is-scheduled { background-color: #3498db !important; }
     </style>
 </head>
 <body>
     <h1 style="text-align: center;">South Shields Metro Departures</h1>
+    <div style="text-align: center; margin-bottom: 20px;">
+        <button id="refresh-btn" aria-label="Refresh departure times" style="padding: 10px 20px; font-size: 1em; cursor: pointer; border-radius: 4px; border: 1px solid #ccc; background: #fff;">Refresh ↻</button>
+    </div>
     
-    <div id="predicted-departure">Predicted next departure time: <span id="prediction-time">Loading...</span></div>
+    <div id="predicted-departure" aria-live="polite">
+        Predicted next departure time: <span id="prediction-time">Loading...</span>
+        <span id="status-label" class="sr-only"></span>
+    </div>
     
     <div class="card">
         <h2>Next Scheduled Times</h2>
@@ -48,8 +57,12 @@
     </div>
     
     <div class="service-analysis">
-        <h2><span class="status-indicator status-info" id="statusIndicator"></span>Next scheduled Departure:</h2>
-        <div id="analysisContent" class="analysis-content">Loading...</div>
+        <h2>
+            <span class="status-indicator status-info" id="statusIndicator"></span>
+            <span id="indicator-text" class="sr-only">Service status: info</span>
+            Next scheduled Departure:
+        </h2>
+        <div id="analysisContent" class="analysis-content" aria-live="polite">Loading...</div>
         <div class="analysis-timestamp" id="analysisTimestamp"></div>
     </div>
     
@@ -81,7 +94,7 @@
             const schedule = getScheduleForDay();
             let upcomingTimes = [];
             if (schedule[currentHour]) {
-                const validMinutes = schedule[currentHour].filter(m => m > currentMinute);
+                const validMinutes = schedule[currentHour].filter(m => m >= currentMinute);
                 upcomingTimes.push(...validMinutes.map(m => ({hour: currentHour, minute: m})));
             }
             let hour = currentHour + 1;
@@ -116,18 +129,22 @@
         async function fetchPrediction() {
             const data = await fetchLiveData('/api/times/CHI/2');
             const predictionSpan = document.getElementById('prediction-time');
+            const statusLabel = document.getElementById('status-label');
+            const container = document.getElementById('predicted-departure');
             
             if (data && data.length > 0) {
                 const now = new Date();
                 const predictedTime = new Date(now.getTime() + (data[0].dueIn - 2) * 60000);
                 predictionSpan.textContent = `${predictedTime.getHours().toString().padStart(2,'0')}:${predictedTime.getMinutes().toString().padStart(2,'0')}`;
-                predictionSpan.parentElement.style.background = '#27ae60'; // Green when live
+                container.className = 'is-live';
+                statusLabel.textContent = '(Live prediction)';
             } else {
                 const nextTimes = getNextScheduledTimes();
                 predictionSpan.textContent = nextTimes.length > 0 
                     ? `${nextTimes[0].hour.toString().padStart(2,'0')}:${nextTimes[0].minute.toString().padStart(2,'0')}`
                     : 'No departures';
-                predictionSpan.parentElement.style.background = '#3498db'; // Blue when static
+                container.className = 'is-scheduled';
+                statusLabel.textContent = '(Scheduled time)';
             }
         }
 
@@ -136,16 +153,22 @@
             const nextScheduled = getNextScheduledTimes();
             const analysisContent = document.getElementById('analysisContent');
             const statusIndicator = document.getElementById('statusIndicator');
+            const indicatorText = document.getElementById('indicator-text');
             const timestampDiv = document.getElementById('analysisTimestamp');
 
             if (nextScheduled.length === 0) {
                 analysisContent.textContent = 'Service has ended for the day.';
                 statusIndicator.className = 'status-indicator status-info';
+                indicatorText.textContent = 'Service status: info';
             } else {
                 const next = nextScheduled[0];
-                const minsUntil = next.hour * 60 + next.minute - (now.getHours() * 60 + now.getMinutes());
-                analysisContent.textContent = `${next.hour.toString().padStart(2,'0')}:${next.minute.toString().padStart(2,'0')} (${minsUntil} mins)`;
+                let minsUntil = next.hour * 60 + next.minute - (now.getHours() * 60 + now.getMinutes());
+                if (minsUntil < 0) minsUntil += 1440; // Wrap around midnight
+                const timeStr = `${next.hour.toString().padStart(2,'0')}:${next.minute.toString().padStart(2,'0')}`;
+                const countdownStr = minsUntil === 0 ? 'Due now' : `${minsUntil} ${minsUntil === 1 ? 'min' : 'mins'}`;
+                analysisContent.textContent = `${timeStr} (${countdownStr})`;
                 statusIndicator.className = 'status-indicator status-info';
+                indicatorText.textContent = 'Service status: info';
             }
             
             timestampDiv.textContent = `Updated: ${now.toLocaleTimeString('en-GB')}`;
@@ -153,11 +176,24 @@
 
         // Load everything
         async function updateAll() {
-            displayScheduledTimes();
-            await fetchPrediction();
-            analyzeService();
+            const refreshBtn = document.getElementById('refresh-btn');
+            if (refreshBtn) {
+                refreshBtn.disabled = true;
+                refreshBtn.textContent = 'Refreshing...';
+            }
+            try {
+                displayScheduledTimes();
+                await fetchPrediction();
+                analyzeService();
+            } finally {
+                if (refreshBtn) {
+                    refreshBtn.disabled = false;
+                    refreshBtn.textContent = 'Refresh ↻';
+                }
+            }
         }
         
+        document.getElementById('refresh-btn').addEventListener('click', updateAll);
         updateAll();
         setInterval(updateAll, 15000);
     </script>


### PR DESCRIPTION
💡 What: Added a manual refresh button, improved screen reader context for live/scheduled statuses, and refined the countdown display.

🎯 Why: Users needed a way to trigger updates manually, and the interface lacked sufficient cues for screen reader users regarding the service state. The countdown also needed to be more intuitive for immediate departures.

📸 Before/After:
- Added a "Refresh ↻" button below the heading.
- The prediction card now explicitly labels itself as "(Live prediction)" or "(Scheduled time)" for screen readers.
- Countdowns now show "Due now" instead of "0 mins".

♿ Accessibility:
- Added `.sr-only` labels for live/scheduled status and service state.
- Implemented `aria-live="polite"` on dynamic departure regions.
- Improved the refresh button with a descriptive `aria-label`.
- Moved from direct JS style manipulation to CSS classes for better maintainability and accessibility.

---
*PR created automatically by Jules for task [9380514928289383735](https://jules.google.com/task/9380514928289383735) started by @ColinPattinson*