### PR TITLE
🎨 Palette: Enhance departure board accessibility and interactivity

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,7 @@
+## 2025-05-14 - Screen Reader Context Pattern
+**Learning:** For dynamic UI updates that use color to convey state (like live vs scheduled data), simply changing the background color is insufficient for accessibility. Using an `aria-live="polite"` container combined with a visually hidden `.sr-only` span that updates its text (e.g., "Live departure: ") ensures that screen reader users receive the same context as visual users.
+**Action:** Always pair visual state changes (color, icons) with a visually hidden text label in an aria-live region.
+
+## 2025-05-14 - Robust Relative Time Displays
+**Learning:** Displaying "0 mins" for immediate events can be confusing. "Due now" provides much better user clarity for transit applications. Additionally, relative time calculations must account for midnight wrap-around (adding 1440 minutes if the difference is negative) to avoid incorrect negative offsets.
+**Action:** Implement "Due now" logic for 0-minute states and always include modulo/day-wrap logic for time-of-day calculations.

--- a/index.html
+++ b/index.html
@@ -35,12 +35,33 @@
             padding: 16px; margin-top: 20px; font-size: 0.95em; color: #856404; 
             text-align: center;
         }
+        .sr-only {
+            position: absolute;
+            width: 1px;
+            height: 1px;
+            padding: 0;
+            margin: -1px;
+            overflow: hidden;
+            clip: rect(0, 0, 0, 0);
+            white-space: nowrap;
+            border-width: 0;
+        }
+        .is-live { background-color: #1e8449 !important; }
+        .is-scheduled { background-color: #2980b9 !important; }
     </style>
 </head>
 <body>
     <h1 style="text-align: center;">South Shields Metro Departures</h1>
     
-    <div id="predicted-departure">Predicted next departure time: <span id="prediction-time">Loading...</span></div>
+    <div id="predicted-departure" aria-live="polite">
+        <span id="status-label" class="sr-only">Checking status...</span>
+        Predicted next departure time: <span id="prediction-time">Loading...</span>
+    </div>
+    <div style="text-align: center; margin-top: -10px; margin-bottom: 20px;">
+        <button id="refresh-btn" style="padding: 8px 16px; border-radius: 4px; border: 1px solid #ccc; cursor: pointer; background: #fff; font-size: 0.9em;">
+            Refresh Departures
+        </button>
+    </div>
     
     <div class="card">
         <h2>Next Scheduled Times</h2>
@@ -81,7 +102,7 @@
             const schedule = getScheduleForDay();
             let upcomingTimes = [];
             if (schedule[currentHour]) {
-                const validMinutes = schedule[currentHour].filter(m => m > currentMinute);
+                const validMinutes = schedule[currentHour].filter(m => m >= currentMinute);
                 upcomingTimes.push(...validMinutes.map(m => ({hour: currentHour, minute: m})));
             }
             let hour = currentHour + 1;
@@ -116,18 +137,22 @@
         async function fetchPrediction() {
             const data = await fetchLiveData('/api/times/CHI/2');
             const predictionSpan = document.getElementById('prediction-time');
+            const statusLabel = document.getElementById('status-label');
+            const container = document.getElementById('predicted-departure');
             
             if (data && data.length > 0) {
                 const now = new Date();
                 const predictedTime = new Date(now.getTime() + (data[0].dueIn - 2) * 60000);
                 predictionSpan.textContent = `${predictedTime.getHours().toString().padStart(2,'0')}:${predictedTime.getMinutes().toString().padStart(2,'0')}`;
-                predictionSpan.parentElement.style.background = '#27ae60'; // Green when live
+                container.className = 'is-live';
+                statusLabel.textContent = 'Live departure: ';
             } else {
                 const nextTimes = getNextScheduledTimes();
                 predictionSpan.textContent = nextTimes.length > 0 
                     ? `${nextTimes[0].hour.toString().padStart(2,'0')}:${nextTimes[0].minute.toString().padStart(2,'0')}`
                     : 'No departures';
-                predictionSpan.parentElement.style.background = '#3498db'; // Blue when static
+                container.className = 'is-scheduled';
+                statusLabel.textContent = 'Scheduled departure: ';
             }
         }
 
@@ -143,8 +168,10 @@
                 statusIndicator.className = 'status-indicator status-info';
             } else {
                 const next = nextScheduled[0];
-                const minsUntil = next.hour * 60 + next.minute - (now.getHours() * 60 + now.getMinutes());
-                analysisContent.textContent = `${next.hour.toString().padStart(2,'0')}:${next.minute.toString().padStart(2,'0')} (${minsUntil} mins)`;
+                let minsUntil = next.hour * 60 + next.minute - (now.getHours() * 60 + now.getMinutes());
+                if (minsUntil < 0) minsUntil += 1440; // Handle midnight wrap
+                const timeText = minsUntil === 0 ? 'Due now' : `${minsUntil} ${minsUntil === 1 ? 'min' : 'mins'}`;
+                analysisContent.textContent = `${next.hour.toString().padStart(2,'0')}:${next.minute.toString().padStart(2,'0')} (${timeText})`;
                 statusIndicator.className = 'status-indicator status-info';
             }
             
@@ -153,11 +180,24 @@
 
         // Load everything
         async function updateAll() {
-            displayScheduledTimes();
-            await fetchPrediction();
-            analyzeService();
+            const refreshBtn = document.getElementById('refresh-btn');
+            if (refreshBtn) {
+                refreshBtn.disabled = true;
+                refreshBtn.textContent = 'Updating...';
+            }
+            try {
+                displayScheduledTimes();
+                await fetchPrediction();
+                analyzeService();
+            } finally {
+                if (refreshBtn) {
+                    refreshBtn.disabled = false;
+                    refreshBtn.textContent = 'Refresh Departures';
+                }
+            }
         }
         
+        document.getElementById('refresh-btn').addEventListener('click', updateAll);
         updateAll();
         setInterval(updateAll, 15000);
     </script>


### PR DESCRIPTION
💡 **What:** This PR adds several micro-UX and accessibility improvements to the South Shields Metro Departures board. Key additions include a manual refresh button, better screen reader support for live/scheduled status, and refined time display logic ("Due now" and pluralization).

🎯 **Why:** 
- Users need a way to manually trigger updates without waiting for the auto-refresh.
- Color alone (green vs. blue) was the only way to tell live data from scheduled data, which is not accessible.
- "0 mins" is less intuitive than "Due now" for transit.
- Negative time offsets occurred during the midnight transition.

📸 **Before/After:**
- Before: Prediction box changed background color silently. Countdown showed "0 mins". No manual refresh.
- After: Prediction box has a hidden label for screen readers. Countdown shows "Due now". A "Refresh" button provides feedback during updates.

♿ **Accessibility:**
- Added `.sr-only` class for visually hidden text.
- Implemented `aria-live="polite"` for dynamic content updates.
- Used high-contrast colors for status states.
- Ensured keyboard accessibility for the new refresh button.

---
*PR created automatically by Jules for task [6640415494505641476](https://jules.google.com/task/6640415494505641476) started by @ColinPattinson*