### PR TITLE
🎨 Palette: Accessibility and Manual Refresh Improvements

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-05-09 - Decoupling manual refresh UI from background auto-refresh
+**Learning:** In applications with both automatic and manual refresh mechanisms, sharing the same update function that modifies UI state (like disabling a button) can lead to unexpected interface locking or visual flickering during background tasks.
+**Action:** Always parameterize the update function (e.g., `isManual`) to ensure visual loading indicators only appear in response to explicit user intent, preserving "invisible" background updates.

--- a/index.html
+++ b/index.html
@@ -35,12 +35,46 @@
             padding: 16px; margin-top: 20px; font-size: 0.95em; color: #856404; 
             text-align: center;
         }
+        .sr-only {
+            position: absolute;
+            width: 1px;
+            height: 1px;
+            padding: 0;
+            margin: -1px;
+            overflow: hidden;
+            clip: rect(0, 0, 0, 0);
+            white-space: nowrap;
+            border-width: 0;
+        }
+        #refresh-btn {
+            display: block;
+            margin: 10px auto;
+            padding: 10px 20px;
+            cursor: pointer;
+            background: #2c3e50;
+            color: white;
+            border: none;
+            border-radius: 4px;
+            font-size: 1em;
+            transition: background 0.3s;
+        }
+        #refresh-btn:hover {
+            background: #34495e;
+        }
+        #refresh-btn:disabled {
+            background: #95a5a6;
+            cursor: not-allowed;
+        }
     </style>
 </head>
 <body>
     <h1 style="text-align: center;">South Shields Metro Departures</h1>
+    <button id="refresh-btn">Refresh Departures</button>
     
-    <div id="predicted-departure">Predicted next departure time: <span id="prediction-time">Loading...</span></div>
+    <div id="predicted-departure" aria-live="polite">
+        <span id="status-label" class="sr-only"></span>
+        Predicted next departure time: <span id="prediction-time">Loading...</span>
+    </div>
     
     <div class="card">
         <h2>Next Scheduled Times</h2>
@@ -48,7 +82,11 @@
     </div>
     
     <div class="service-analysis">
-        <h2><span class="status-indicator status-info" id="statusIndicator"></span>Next scheduled Departure:</h2>
+        <h2>
+            <span class="status-indicator status-info" id="statusIndicator"></span>
+            <span id="indicator-text" class="sr-only"></span>
+            Next scheduled Departure:
+        </h2>
         <div id="analysisContent" class="analysis-content">Loading...</div>
         <div class="analysis-timestamp" id="analysisTimestamp"></div>
     </div>
@@ -116,18 +154,21 @@
         async function fetchPrediction() {
             const data = await fetchLiveData('/api/times/CHI/2');
             const predictionSpan = document.getElementById('prediction-time');
+            const statusLabel = document.getElementById('status-label');
             
             if (data && data.length > 0) {
                 const now = new Date();
                 const predictedTime = new Date(now.getTime() + (data[0].dueIn - 2) * 60000);
                 predictionSpan.textContent = `${predictedTime.getHours().toString().padStart(2,'0')}:${predictedTime.getMinutes().toString().padStart(2,'0')}`;
                 predictionSpan.parentElement.style.background = '#27ae60'; // Green when live
+                statusLabel.textContent = 'Live prediction: ';
             } else {
                 const nextTimes = getNextScheduledTimes();
                 predictionSpan.textContent = nextTimes.length > 0 
                     ? `${nextTimes[0].hour.toString().padStart(2,'0')}:${nextTimes[0].minute.toString().padStart(2,'0')}`
                     : 'No departures';
                 predictionSpan.parentElement.style.background = '#3498db'; // Blue when static
+                statusLabel.textContent = 'Scheduled departure: ';
             }
         }
 
@@ -136,30 +177,49 @@
             const nextScheduled = getNextScheduledTimes();
             const analysisContent = document.getElementById('analysisContent');
             const statusIndicator = document.getElementById('statusIndicator');
+            const indicatorText = document.getElementById('indicator-text');
             const timestampDiv = document.getElementById('analysisTimestamp');
 
             if (nextScheduled.length === 0) {
                 analysisContent.textContent = 'Service has ended for the day.';
                 statusIndicator.className = 'status-indicator status-info';
+                indicatorText.textContent = 'Service ended';
             } else {
                 const next = nextScheduled[0];
                 const minsUntil = next.hour * 60 + next.minute - (now.getHours() * 60 + now.getMinutes());
                 analysisContent.textContent = `${next.hour.toString().padStart(2,'0')}:${next.minute.toString().padStart(2,'0')} (${minsUntil} mins)`;
                 statusIndicator.className = 'status-indicator status-info';
+                indicatorText.textContent = 'Service OK';
             }
             
             timestampDiv.textContent = `Updated: ${now.toLocaleTimeString('en-GB')}`;
         }
 
         // Load everything
-        async function updateAll() {
-            displayScheduledTimes();
-            await fetchPrediction();
-            analyzeService();
+        async function updateAll(isManual = false) {
+            const refreshBtn = document.getElementById('refresh-btn');
+            const originalText = refreshBtn.textContent;
+
+            try {
+                if (isManual) {
+                    refreshBtn.disabled = true;
+                    refreshBtn.textContent = 'Updating...';
+                }
+                displayScheduledTimes();
+                await fetchPrediction();
+                analyzeService();
+            } finally {
+                if (isManual) {
+                    refreshBtn.disabled = false;
+                    refreshBtn.textContent = originalText;
+                }
+            }
         }
         
+        document.getElementById('refresh-btn').addEventListener('click', () => updateAll(true));
+
         updateAll();
-        setInterval(updateAll, 15000);
+        setInterval(() => updateAll(), 15000);
     </script>
 </body>
 </html>


### PR DESCRIPTION
💡 What: Added a manual refresh button with a loading state and enhanced dynamic regions with ARIA accessibility attributes.
🎯 Why: Users previously had no way to manually trigger an update, and dynamic content changes (like predictions switching between live and scheduled modes) were not announced to screen readers.
📸 Before/After: A dark-themed "Refresh Departures" button was added below the header. The prediction container now includes visually hidden labels for context.
♿ Accessibility: Implemented `aria-live="polite"` on the `#predicted-departure` container and added `.sr-only` spans to communicate the status of predictions (Live vs Scheduled) and service indicators (Service OK).

---
*PR created automatically by Jules for task [2177039547590018600](https://jules.google.com/task/2177039547590018600) started by @ColinPattinson*