### PR TITLE
🎨 Palette: Accessible status indicators for departures

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-05-13 - Screen Reader Context Pattern
+**Learning:** Purely visual cues like background color changes (e.g., green for Live, blue for Scheduled) are invisible to screen reader users. The 'Screen Reader Context Pattern' uses a visually hidden `.sr-only` element to provide this missing state information in text form.
+**Action:** Always pair visual state changes with a hidden text alternative and use `aria-live` to ensure the update is announced when the state changes dynamically.

--- a/index.html
+++ b/index.html
@@ -9,6 +9,19 @@
         #predicted-departure {
             background: #3498db; color: white; padding: 20px; border-radius: 8px; 
             margin: 20px 0; font-size: 2em; text-align: center;
+            transition: background-color 0.3s ease;
+        }
+        .is-live { background-color: #1e8449 !important; }
+        .is-scheduled { background-color: #2980b9 !important; }
+        .status-badge {
+            font-size: 0.5em; vertical-align: middle; padding: 4px 8px;
+            border-radius: 4px; background: rgba(255,255,255,0.2);
+            margin-left: 10px; text-transform: uppercase; font-weight: bold;
+            display: inline-block; line-height: 1;
+        }
+        .sr-only {
+            position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px;
+            overflow: hidden; clip: rect(0, 0, 0, 0); white-space: nowrap; border-width: 0;
         }
         .card { 
             background: #f5f5f5; padding: 20px; border-radius: 8px; margin: 20px 0;
@@ -40,7 +53,11 @@
 <body>
     <h1 style="text-align: center;">South Shields Metro Departures</h1>
     
-    <div id="predicted-departure">Predicted next departure time: <span id="prediction-time">Loading...</span></div>
+    <div id="predicted-departure" aria-live="polite">
+        <span id="status-label" class="sr-only">Checking status...</span>
+        Predicted next departure time: <span id="prediction-time">Loading...</span>
+        <span id="status-badge" class="status-badge" aria-hidden="true" style="display: none;"></span>
+    </div>
     
     <div class="card">
         <h2>Next Scheduled Times</h2>
@@ -116,18 +133,31 @@
         async function fetchPrediction() {
             const data = await fetchLiveData('/api/times/CHI/2');
             const predictionSpan = document.getElementById('prediction-time');
+            const container = document.getElementById('predicted-departure');
+            const statusLabel = document.getElementById('status-label');
+            const statusBadge = document.getElementById('status-badge');
             
             if (data && data.length > 0) {
                 const now = new Date();
                 const predictedTime = new Date(now.getTime() + (data[0].dueIn - 2) * 60000);
                 predictionSpan.textContent = `${predictedTime.getHours().toString().padStart(2,'0')}:${predictedTime.getMinutes().toString().padStart(2,'0')}`;
-                predictionSpan.parentElement.style.background = '#27ae60'; // Green when live
+
+                container.classList.remove('is-scheduled');
+                container.classList.add('is-live');
+                statusLabel.textContent = 'Live departure: ';
+                statusBadge.textContent = 'Live';
+                statusBadge.style.display = 'inline-block';
             } else {
                 const nextTimes = getNextScheduledTimes();
                 predictionSpan.textContent = nextTimes.length > 0 
                     ? `${nextTimes[0].hour.toString().padStart(2,'0')}:${nextTimes[0].minute.toString().padStart(2,'0')}`
                     : 'No departures';
-                predictionSpan.parentElement.style.background = '#3498db'; // Blue when static
+
+                container.classList.remove('is-live');
+                container.classList.add('is-scheduled');
+                statusLabel.textContent = 'Scheduled departure: ';
+                statusBadge.textContent = 'Scheduled';
+                statusBadge.style.display = 'inline-block';
             }
         }
 


### PR DESCRIPTION
### 💡 What
Added a visible "LIVE" or "SCHEDULED" status badge to the next departure display, along with a smooth background color transition.

### 🎯 Why
Previously, the interface only used color to distinguish between live data and scheduled backups. This was ambiguous for color-blind users and provided no context for screen reader users. Now, the state is explicitly communicated via text.

### 📸 Before/After
- **Before:** A solid blue or green box showing only the time.
- **After:** A refined box with a "LIVE" or "SCHEDULED" badge, and a smooth 0.3s transition when the data source changes.

### ♿ Accessibility
- Introduced a `.sr-only` class for screen-reader-specific labels ("Live departure:" vs "Scheduled departure:").
- Added `aria-live="polite"` to the departure container so updates are announced.
- Improved color contrast for status states (#1e8449 for Live, #2980b9 for Scheduled) to meet WCAG AA standards.
- Marked visual badges as `aria-hidden="true"` to avoid redundant announcements.

---
*PR created automatically by Jules for task [9935361073400869919](https://jules.google.com/task/9935361073400869919) started by @ColinPattinson*