### PR TITLE
🎨 Palette: Improve accessibility and clarity of departure times

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,7 @@
+## 2024-05-17 - Screen Reader Context for Color-Coded States
+**Learning:** When using color to communicate state (e.g., green for 'Live' vs blue for 'Scheduled'), visual-only indicators are insufficient for accessibility. Using a visually hidden element (`.sr-only`) that updates alongside the visual change ensures screen reader users receive the same information.
+**Action:** Always pair color-based state changes with a corresponding `.sr-only` text label or ARIA attribute.
+
+## 2024-05-17 - Inclusive Time Filtering for "Due Now" States
+**Learning:** Standard time-remaining logic often uses strict inequality (m > currentMinute), which causes a "gap" where an item disappears exactly when it is due. Using inclusive inequality (m >= currentMinute) allows the UI to display a "Due now" state, providing better clarity for users.
+**Action:** Use inclusive filtering for countdowns and implement a specific "Due now" string for 0-minute wait times.

--- a/index.html
+++ b/index.html
@@ -35,12 +35,26 @@
             padding: 16px; margin-top: 20px; font-size: 0.95em; color: #856404; 
             text-align: center;
         }
+        .sr-only {
+            position: absolute;
+            width: 1px;
+            height: 1px;
+            padding: 0;
+            margin: -1px;
+            overflow: hidden;
+            clip: rect(0, 0, 0, 0);
+            white-space: nowrap;
+            border-width: 0;
+        }
     </style>
 </head>
 <body>
     <h1 style="text-align: center;">South Shields Metro Departures</h1>
     
-    <div id="predicted-departure">Predicted next departure time: <span id="prediction-time">Loading...</span></div>
+    <div id="predicted-departure" aria-live="polite">
+        Predicted next departure time: <span id="prediction-time">Loading...</span>
+        <span id="status-label" class="sr-only"></span>
+    </div>
     
     <div class="card">
         <h2>Next Scheduled Times</h2>
@@ -48,7 +62,7 @@
     </div>
     
     <div class="service-analysis">
-        <h2><span class="status-indicator status-info" id="statusIndicator"></span>Next scheduled Departure:</h2>
+        <h2><span class="status-indicator status-info" id="statusIndicator" aria-hidden="true"></span>Next scheduled Departure:</h2>
         <div id="analysisContent" class="analysis-content">Loading...</div>
         <div class="analysis-timestamp" id="analysisTimestamp"></div>
     </div>
@@ -81,7 +95,7 @@
             const schedule = getScheduleForDay();
             let upcomingTimes = [];
             if (schedule[currentHour]) {
-                const validMinutes = schedule[currentHour].filter(m => m > currentMinute);
+                const validMinutes = schedule[currentHour].filter(m => m >= currentMinute);
                 upcomingTimes.push(...validMinutes.map(m => ({hour: currentHour, minute: m})));
             }
             let hour = currentHour + 1;
@@ -116,18 +130,21 @@
         async function fetchPrediction() {
             const data = await fetchLiveData('/api/times/CHI/2');
             const predictionSpan = document.getElementById('prediction-time');
+            const statusLabel = document.getElementById('status-label');
             
             if (data && data.length > 0) {
                 const now = new Date();
                 const predictedTime = new Date(now.getTime() + (data[0].dueIn - 2) * 60000);
                 predictionSpan.textContent = `${predictedTime.getHours().toString().padStart(2,'0')}:${predictedTime.getMinutes().toString().padStart(2,'0')}`;
                 predictionSpan.parentElement.style.background = '#27ae60'; // Green when live
+                statusLabel.textContent = '(Live)';
             } else {
                 const nextTimes = getNextScheduledTimes();
                 predictionSpan.textContent = nextTimes.length > 0 
                     ? `${nextTimes[0].hour.toString().padStart(2,'0')}:${nextTimes[0].minute.toString().padStart(2,'0')}`
                     : 'No departures';
                 predictionSpan.parentElement.style.background = '#3498db'; // Blue when static
+                statusLabel.textContent = '(Scheduled)';
             }
         }
 
@@ -144,7 +161,15 @@
             } else {
                 const next = nextScheduled[0];
                 const minsUntil = next.hour * 60 + next.minute - (now.getHours() * 60 + now.getMinutes());
-                analysisContent.textContent = `${next.hour.toString().padStart(2,'0')}:${next.minute.toString().padStart(2,'0')} (${minsUntil} mins)`;
+
+                let countdownText = '';
+                if (minsUntil === 0) {
+                    countdownText = 'Due now';
+                } else {
+                    countdownText = `${minsUntil} ${minsUntil === 1 ? 'min' : 'mins'}`;
+                }
+
+                analysisContent.textContent = `${next.hour.toString().padStart(2,'0')}:${next.minute.toString().padStart(2,'0')} (${countdownText})`;
                 statusIndicator.className = 'status-indicator status-info';
             }
             


### PR DESCRIPTION
💡 What: Improved the accessibility and clarity of departure times by adding ARIA live regions, visually hidden labels for state (Live vs Scheduled), 'Due now' text for 0-minute waits, and correct pluralization for wait times. Also fixed a bug to include trains departing in the current minute.

🎯 Why: The previous interface relied on background color alone to communicate if a time was Live or Scheduled, which is not accessible. Additionally, the countdown logic excluded trains in the current minute, causing them to disappear abruptly.

📸 Before/After: 
- Before: '8 mins', '08:08' (disappears at 08:08), background color only for Live status.
- After: '8 mins', '1 min', 'Due now', '(Live)'/'(Scheduled)' screen-reader labels, aria-live for updates.

♿ Accessibility:
- Added `.sr-only` class for accessible-only text.
- Added `aria-live="polite"` to the predicted departure.
- Added `aria-hidden="true"` to decorative status dots.
- Ensured color-coded status is also available as text.

---
*PR created automatically by Jules for task [13296271894172311301](https://jules.google.com/task/13296271894172311301) started by @ColinPattinson*