### PR TITLE
🎨 Palette: Enhanced Accessibility and Visual Feedback

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,7 @@
+## 2025-05-14 - Screen Reader Context Pattern
+**Learning:** Purely visual indicators (like background color changes or status dots) are invisible to screen reader users. Using a visually hidden span (`.sr-only`) that updates its text alongside visual changes ensures assistive technology users receive the same state information (e.g., "Live" vs "Scheduled").
+**Action:** Always pair visual-only state changes (colors, icons) with `.sr-only` descriptive text or ARIA attributes.
+
+## 2025-05-14 - Accessible Color Contrast for Status Indicators
+**Learning:** Standard brand colors (like light blue #3498db or light green #27ae60) often fail WCAG AA contrast ratios (4.5:1) when paired with white text.
+**Action:** Use darker variations (e.g., #206694 for blue, #1b7a43 for green) to ensure readability for users with visual impairments while maintaining the "color meaning" of the status.

--- a/index.html
+++ b/index.html
@@ -7,8 +7,21 @@
     <style>
         body { font-family: Arial, sans-serif; margin: 20px; }
         #predicted-departure {
-            background: #3498db; color: white; padding: 20px; border-radius: 8px; 
+            color: white; padding: 20px; border-radius: 8px;
             margin: 20px 0; font-size: 2em; text-align: center;
+        }
+        .is-live { background: #1b7a43 !important; }
+        .is-scheduled { background: #206694 !important; }
+        .sr-only {
+            position: absolute;
+            width: 1px;
+            height: 1px;
+            padding: 0;
+            margin: -1px;
+            overflow: hidden;
+            clip: rect(0, 0, 0, 0);
+            white-space: nowrap;
+            border-width: 0;
         }
         .card { 
             background: #f5f5f5; padding: 20px; border-radius: 8px; margin: 20px 0;
@@ -40,7 +53,10 @@
 <body>
     <h1 style="text-align: center;">South Shields Metro Departures</h1>
     
-    <div id="predicted-departure">Predicted next departure time: <span id="prediction-time">Loading...</span></div>
+    <div id="predicted-departure" aria-live="polite" aria-atomic="true" class="is-scheduled">
+        <span id="status-label" class="sr-only">Scheduled departure:</span>
+        Next departure: <span id="prediction-time">Loading...</span>
+    </div>
     
     <div class="card">
         <h2>Next Scheduled Times</h2>
@@ -48,8 +64,12 @@
     </div>
     
     <div class="service-analysis">
-        <h2><span class="status-indicator status-info" id="statusIndicator"></span>Next scheduled Departure:</h2>
-        <div id="analysisContent" class="analysis-content">Loading...</div>
+        <h2>
+            <span class="status-indicator status-info" id="statusIndicator" aria-hidden="true"></span>
+            <span id="indicator-text" class="sr-only">Service status: info.</span>
+            Next scheduled Departure:
+        </h2>
+        <div id="analysisContent" class="analysis-content" aria-live="polite">Loading...</div>
         <div class="analysis-timestamp" id="analysisTimestamp"></div>
     </div>
     
@@ -81,7 +101,7 @@
             const schedule = getScheduleForDay();
             let upcomingTimes = [];
             if (schedule[currentHour]) {
-                const validMinutes = schedule[currentHour].filter(m => m > currentMinute);
+                const validMinutes = schedule[currentHour].filter(m => m >= currentMinute);
                 upcomingTimes.push(...validMinutes.map(m => ({hour: currentHour, minute: m})));
             }
             let hour = currentHour + 1;
@@ -116,18 +136,24 @@
         async function fetchPrediction() {
             const data = await fetchLiveData('/api/times/CHI/2');
             const predictionSpan = document.getElementById('prediction-time');
+            const container = predictionSpan.parentElement;
+            const statusLabel = document.getElementById('status-label');
             
             if (data && data.length > 0) {
                 const now = new Date();
                 const predictedTime = new Date(now.getTime() + (data[0].dueIn - 2) * 60000);
                 predictionSpan.textContent = `${predictedTime.getHours().toString().padStart(2,'0')}:${predictedTime.getMinutes().toString().padStart(2,'0')}`;
-                predictionSpan.parentElement.style.background = '#27ae60'; // Green when live
+                statusLabel.textContent = 'Live departure:';
+                container.classList.remove('is-scheduled');
+                container.classList.add('is-live');
             } else {
                 const nextTimes = getNextScheduledTimes();
                 predictionSpan.textContent = nextTimes.length > 0 
                     ? `${nextTimes[0].hour.toString().padStart(2,'0')}:${nextTimes[0].minute.toString().padStart(2,'0')}`
                     : 'No departures';
-                predictionSpan.parentElement.style.background = '#3498db'; // Blue when static
+                statusLabel.textContent = 'Scheduled departure:';
+                container.classList.remove('is-live');
+                container.classList.add('is-scheduled');
             }
         }
 
@@ -136,16 +162,26 @@
             const nextScheduled = getNextScheduledTimes();
             const analysisContent = document.getElementById('analysisContent');
             const statusIndicator = document.getElementById('statusIndicator');
+            const indicatorText = document.getElementById('indicator-text');
             const timestampDiv = document.getElementById('analysisTimestamp');
 
             if (nextScheduled.length === 0) {
                 analysisContent.textContent = 'Service has ended for the day.';
                 statusIndicator.className = 'status-indicator status-info';
+                indicatorText.textContent = 'Service status: ended.';
             } else {
                 const next = nextScheduled[0];
                 const minsUntil = next.hour * 60 + next.minute - (now.getHours() * 60 + now.getMinutes());
-                analysisContent.textContent = `${next.hour.toString().padStart(2,'0')}:${next.minute.toString().padStart(2,'0')} (${minsUntil} mins)`;
+                let timeStr = `${next.hour.toString().padStart(2,'0')}:${next.minute.toString().padStart(2,'0')}`;
+
+                if (minsUntil === 0) {
+                    analysisContent.textContent = `${timeStr} (Due now)`;
+                } else {
+                    analysisContent.textContent = `${timeStr} (${minsUntil} ${minsUntil === 1 ? 'min' : 'mins'})`;
+                }
+
                 statusIndicator.className = 'status-indicator status-info';
+                indicatorText.textContent = 'Service status: info.';
             }
             
             timestampDiv.textContent = `Updated: ${now.toLocaleTimeString('en-GB')}`;


### PR DESCRIPTION
### 💡 What
This PR enhances the South Shields Metro Departures board with several micro-UX and accessibility improvements:
- **WCAG-Compliant Colors:** Replaced brand colors with higher-contrast variations (#1b7a43 and #206694) to ensure a 4.5:1 contrast ratio against white text.
- **Screen Reader Support:** Implemented the "Screen Reader Context Pattern" using `.sr-only` classes to announce "Live departure" or "Scheduled departure" status, and added `aria-live="polite"` for dynamic updates.
- **Polished Countdown Logic:** Added a "Due now" state for 0-minute countdowns and fixed "min" vs "mins" pluralization.
- **Inclusive Timing:** Fixed a bug in `getNextScheduledTimes` to include trains due in the current minute.

### 🎯 Why
The previous interface relied purely on color to communicate "Live" vs "Scheduled" status, which is inaccessible to color-blind and screen-reader users. Additionally, the color contrast was below standard, and the timing logic occasionally missed immediate departures.

### ♿ Accessibility
- Added `aria-live="polite"` and `aria-atomic="true"` to the main departure display.
- Added visually hidden status labels for context.
- Ensured all status indicators are accessible via text.
- Marked decorative icons as `aria-hidden="true"`.

### 📸 Visuals
- **Live State:** Deep Green (#1b7a43)
- **Scheduled State:** Deep Blue (#206694)
- **Countdown:** Displays "Due now" when appropriate.

---
*PR created automatically by Jules for task [4974075869506412312](https://jules.google.com/task/4974075869506412312) started by @ColinPattinson*