### PR TITLE
🎨 Palette: Enhance departure status clarity and accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-05-20 - Screen Reader Context Pattern
+**Learning:** For single-page apps that communicate state via background colors (e.g., Live vs. Scheduled), visual-only cues are inaccessible to screen reader users and those with color blindness. Using a visually hidden element (`.sr-only`) that updates its text content alongside visual changes ensures all users receive the same state information.
+**Action:** Always pair visual state indicators with an accessible text label using the `.sr-only` pattern and use `aria-live` on the container to announce updates.

--- a/index.html
+++ b/index.html
@@ -35,12 +35,26 @@
             padding: 16px; margin-top: 20px; font-size: 0.95em; color: #856404; 
             text-align: center;
         }
+        .sr-only {
+            position: absolute;
+            width: 1px;
+            height: 1px;
+            padding: 0;
+            margin: -1px;
+            overflow: hidden;
+            clip: rect(0, 0, 0, 0);
+            white-space: nowrap;
+            border-width: 0;
+        }
     </style>
 </head>
 <body>
     <h1 style="text-align: center;">South Shields Metro Departures</h1>
     
-    <div id="predicted-departure">Predicted next departure time: <span id="prediction-time">Loading...</span></div>
+    <div id="predicted-departure" aria-live="polite">
+        <span id="status-label" class="sr-only"></span>
+        Predicted next departure time: <span id="prediction-time">Loading...</span>
+    </div>
     
     <div class="card">
         <h2>Next Scheduled Times</h2>
@@ -48,7 +62,11 @@
     </div>
     
     <div class="service-analysis">
-        <h2><span class="status-indicator status-info" id="statusIndicator"></span>Next scheduled Departure:</h2>
+        <h2>
+            <span class="status-indicator status-info" id="statusIndicator" aria-hidden="true"></span>
+            <span id="indicator-text" class="sr-only"></span>
+            Next scheduled Departure:
+        </h2>
         <div id="analysisContent" class="analysis-content">Loading...</div>
         <div class="analysis-timestamp" id="analysisTimestamp"></div>
     </div>
@@ -81,7 +99,7 @@
             const schedule = getScheduleForDay();
             let upcomingTimes = [];
             if (schedule[currentHour]) {
-                const validMinutes = schedule[currentHour].filter(m => m > currentMinute);
+                const validMinutes = schedule[currentHour].filter(m => m >= currentMinute);
                 upcomingTimes.push(...validMinutes.map(m => ({hour: currentHour, minute: m})));
             }
             let hour = currentHour + 1;
@@ -116,18 +134,21 @@
         async function fetchPrediction() {
             const data = await fetchLiveData('/api/times/CHI/2');
             const predictionSpan = document.getElementById('prediction-time');
+            const statusLabel = document.getElementById('status-label');
             
             if (data && data.length > 0) {
                 const now = new Date();
                 const predictedTime = new Date(now.getTime() + (data[0].dueIn - 2) * 60000);
                 predictionSpan.textContent = `${predictedTime.getHours().toString().padStart(2,'0')}:${predictedTime.getMinutes().toString().padStart(2,'0')}`;
-                predictionSpan.parentElement.style.background = '#27ae60'; // Green when live
+                predictionSpan.parentElement.style.background = '#1b7a43'; // Accessible green
+                statusLabel.textContent = 'Live prediction: ';
             } else {
                 const nextTimes = getNextScheduledTimes();
                 predictionSpan.textContent = nextTimes.length > 0 
                     ? `${nextTimes[0].hour.toString().padStart(2,'0')}:${nextTimes[0].minute.toString().padStart(2,'0')}`
                     : 'No departures';
-                predictionSpan.parentElement.style.background = '#3498db'; // Blue when static
+                predictionSpan.parentElement.style.background = '#206694'; // Accessible blue
+                statusLabel.textContent = 'Scheduled departure: ';
             }
         }
 
@@ -136,16 +157,20 @@
             const nextScheduled = getNextScheduledTimes();
             const analysisContent = document.getElementById('analysisContent');
             const statusIndicator = document.getElementById('statusIndicator');
+            const indicatorText = document.getElementById('indicator-text');
             const timestampDiv = document.getElementById('analysisTimestamp');
 
             if (nextScheduled.length === 0) {
                 analysisContent.textContent = 'Service has ended for the day.';
                 statusIndicator.className = 'status-indicator status-info';
+                indicatorText.textContent = 'Status: End of service';
             } else {
                 const next = nextScheduled[0];
                 const minsUntil = next.hour * 60 + next.minute - (now.getHours() * 60 + now.getMinutes());
-                analysisContent.textContent = `${next.hour.toString().padStart(2,'0')}:${next.minute.toString().padStart(2,'0')} (${minsUntil} mins)`;
+                const timeText = minsUntil === 0 ? 'Due now' : `${minsUntil} ${minsUntil === 1 ? 'min' : 'mins'}`;
+                analysisContent.textContent = `${next.hour.toString().padStart(2,'0')}:${next.minute.toString().padStart(2,'0')} (${timeText})`;
                 statusIndicator.className = 'status-indicator status-info';
+                indicatorText.textContent = 'Status: Service is regular';
             }
             
             timestampDiv.textContent = `Updated: ${now.toLocaleTimeString('en-GB')}`;


### PR DESCRIPTION
### 💡 What
This enhancement adds small but significant UX and accessibility improvements to the South Shields Metro Departures interface. It replaces the "0 mins" countdown with a clearer "Due now" label, fixes minute pluralization (e.g., "1 min" vs "2 mins"), and introduces a robust "Screen Reader Context Pattern".

### 🎯 Why
The interface previously relied on background colors to indicate whether a departure time was a "Live prediction" (green) or a "Scheduled departure" (blue), which was inaccessible to screen reader users and those with color blindness. Additionally, the countdown logic was slightly imprecise.

### ♿ Accessibility
- **Screen Reader Context:** Added visually hidden spans (`.sr-only`) that update their text alongside the visual color changes, ensuring everyone knows the data source.
- **Live Regions:** Applied `aria-live="polite"` to the main departure container so updates are automatically announced to assistive technologies.
- **Color Contrast:** Updated the background colors to `#1b7a43` (Live) and `#206694` (Scheduled) to meet WCAG standards for white text contrast.
- **Semantic Hiding:** Used `aria-hidden="true"` on decorative status dots to reduce screen reader noise.

### 📸 Visuals
The main departure block now clearly distinguishes between live and scheduled data through both color and accessible labels, and the service analysis provides more natural human-readable timing.

### 🧪 Verification
Verified using Playwright (mocking API responses and system time) to confirm:
- "Due now" appears at 0 minutes.
- "1 min" is singular, "2 mins" is plural.
- ARIA labels and live regions update correctly.
- Fallback to scheduled data works seamlessly.

---
*PR created automatically by Jules for task [18020874347604260741](https://jules.google.com/task/18020874347604260741) started by @ColinPattinson*