### PR TITLE
🎨 Palette: Improve accessibility and clarity of departure countdowns

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,7 @@
+## 2026-05-22 - Screen Reader Context Pattern
+**Learning:** Visual-only state indicators (like background colors for 'Live' vs 'Scheduled') are inaccessible to screen readers and color-blind users unless accompanied by text or specific ARIA attributes.
+**Action:** Use a visually hidden span (`.sr-only`) that updates its text content alongside visual changes to provide equitable state information to all users.
+
+## 2026-05-22 - Intuitive Transit Countdown
+**Learning:** Displaying "0 mins" for a departing transit vehicle can be ambiguous and lacks urgency.
+**Action:** Use "Due now" for zero-minute countdowns to provide immediate, clear, and actionable feedback to the user.

--- a/index.html
+++ b/index.html
@@ -15,7 +15,7 @@
             max-width: 600px; margin-left: auto; margin-right: auto;
         }
         .service-analysis { 
-            background: #fff; border: 2px solid #3498db; border-radius: 8px; 
+            background: #fff; border: 2px solid #206694; border-radius: 8px;
             padding: 24px; margin-top: 20px; box-shadow: 0 2px 8px rgba(0,0,0,0.1); 
         }
         .service-analysis h2 { 
@@ -35,12 +35,26 @@
             padding: 16px; margin-top: 20px; font-size: 0.95em; color: #856404; 
             text-align: center;
         }
+        .sr-only {
+            position: absolute;
+            width: 1px;
+            height: 1px;
+            padding: 0;
+            margin: -1px;
+            overflow: hidden;
+            clip: rect(0, 0, 0, 0);
+            white-space: nowrap;
+            border-width: 0;
+        }
     </style>
 </head>
 <body>
     <h1 style="text-align: center;">South Shields Metro Departures</h1>
     
-    <div id="predicted-departure">Predicted next departure time: <span id="prediction-time">Loading...</span></div>
+    <div id="predicted-departure" aria-live="polite">
+        Predicted next departure time: <span id="prediction-time">Loading...</span>
+        <span id="status-label" class="sr-only"></span>
+    </div>
     
     <div class="card">
         <h2>Next Scheduled Times</h2>
@@ -48,7 +62,11 @@
     </div>
     
     <div class="service-analysis">
-        <h2><span class="status-indicator status-info" id="statusIndicator"></span>Next scheduled Departure:</h2>
+        <h2>
+            <span class="status-indicator status-info" id="statusIndicator" aria-hidden="true"></span>
+            <span id="indicator-text" class="sr-only">Service status: Info.</span>
+            Next scheduled Departure:
+        </h2>
         <div id="analysisContent" class="analysis-content">Loading...</div>
         <div class="analysis-timestamp" id="analysisTimestamp"></div>
     </div>
@@ -81,7 +99,7 @@
             const schedule = getScheduleForDay();
             let upcomingTimes = [];
             if (schedule[currentHour]) {
-                const validMinutes = schedule[currentHour].filter(m => m > currentMinute);
+                const validMinutes = schedule[currentHour].filter(m => m >= currentMinute);
                 upcomingTimes.push(...validMinutes.map(m => ({hour: currentHour, minute: m})));
             }
             let hour = currentHour + 1;
@@ -116,18 +134,21 @@
         async function fetchPrediction() {
             const data = await fetchLiveData('/api/times/CHI/2');
             const predictionSpan = document.getElementById('prediction-time');
+            const statusLabel = document.getElementById('status-label');
             
             if (data && data.length > 0) {
                 const now = new Date();
                 const predictedTime = new Date(now.getTime() + (data[0].dueIn - 2) * 60000);
                 predictionSpan.textContent = `${predictedTime.getHours().toString().padStart(2,'0')}:${predictedTime.getMinutes().toString().padStart(2,'0')}`;
-                predictionSpan.parentElement.style.background = '#27ae60'; // Green when live
+                predictionSpan.parentElement.style.background = '#1b7a43'; // Green when live
+                statusLabel.textContent = '(Live prediction)';
             } else {
                 const nextTimes = getNextScheduledTimes();
                 predictionSpan.textContent = nextTimes.length > 0 
                     ? `${nextTimes[0].hour.toString().padStart(2,'0')}:${nextTimes[0].minute.toString().padStart(2,'0')}`
                     : 'No departures';
-                predictionSpan.parentElement.style.background = '#3498db'; // Blue when static
+                predictionSpan.parentElement.style.background = '#206694'; // Blue when static
+                statusLabel.textContent = '(Scheduled time)';
             }
         }
 
@@ -136,16 +157,20 @@
             const nextScheduled = getNextScheduledTimes();
             const analysisContent = document.getElementById('analysisContent');
             const statusIndicator = document.getElementById('statusIndicator');
+            const indicatorText = document.getElementById('indicator-text');
             const timestampDiv = document.getElementById('analysisTimestamp');
 
             if (nextScheduled.length === 0) {
                 analysisContent.textContent = 'Service has ended for the day.';
                 statusIndicator.className = 'status-indicator status-info';
+                indicatorText.textContent = 'Service status: Service ended.';
             } else {
                 const next = nextScheduled[0];
                 const minsUntil = next.hour * 60 + next.minute - (now.getHours() * 60 + now.getMinutes());
-                analysisContent.textContent = `${next.hour.toString().padStart(2,'0')}:${next.minute.toString().padStart(2,'0')} (${minsUntil} mins)`;
+                const countdownText = minsUntil === 0 ? 'Due now' : `${minsUntil} ${minsUntil === 1 ? 'min' : 'mins'}`;
+                analysisContent.textContent = `${next.hour.toString().padStart(2,'0')}:${next.minute.toString().padStart(2,'0')} (${countdownText})`;
                 statusIndicator.className = 'status-indicator status-info';
+                indicatorText.textContent = 'Service status: Info.';
             }
             
             timestampDiv.textContent = `Updated: ${now.toLocaleTimeString('en-GB')}`;


### PR DESCRIPTION
💡 What: This enhancement improves the accessibility and clarity of the metro departure displays. It introduces WCAG-compliant status colors, adds screen reader support for live vs. scheduled states, and refines the countdown wording.

🎯 Why: The previous interface relied solely on color to communicate state, which is inaccessible to screen-reader users and difficult for color-blind users. Additionally, "0 mins" is less intuitive than "Due now", and the schedule logic had a minor gap where it skipped the current minute.

📸 Before/After:
- Before: "0 mins" (Light blue/green background)
- After: "Due now" (Darker, high-contrast #206694/#1b7a43 backgrounds)

♿ Accessibility:
- Added `aria-live="polite"` to ensure real-time updates are announced.
- Used the "Screen Reader Context Pattern" with `.sr-only` labels to explain visual states.
- Improved color contrast ratios for white text on status backgrounds.
- Added visually hidden descriptions for status indicator icons.

---
*PR created automatically by Jules for task [11895719329915531797](https://jules.google.com/task/11895719329915531797) started by @ColinPattinson*