### PR TITLE
🎨 Palette: Enhanced Departure Clarity & Accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-05-23 - Screen Reader Context Pattern
+**Learning:** Color-coded states (like Green for Live and Blue for Scheduled) are inaccessible to screen reader and color-blind users without accompanying text. Using a visually hidden `.sr-only` span that updates its text alongside visual changes ensures that all users receive the same state information.
+**Action:** Always pair visual-only state indicators with an `.sr-only` element that provides a text description of the current state. Use `aria-live="polite"` on the parent container to ensure these updates are announced.

--- a/index.html
+++ b/index.html
@@ -10,12 +10,16 @@
             background: #3498db; color: white; padding: 20px; border-radius: 8px; 
             margin: 20px 0; font-size: 2em; text-align: center;
         }
+        .sr-only {
+            position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px;
+            overflow: hidden; clip: rect(0, 0, 0, 0); white-space: nowrap; border-width: 0;
+        }
         .card { 
             background: #f5f5f5; padding: 20px; border-radius: 8px; margin: 20px 0;
             max-width: 600px; margin-left: auto; margin-right: auto;
         }
         .service-analysis { 
-            background: #fff; border: 2px solid #3498db; border-radius: 8px; 
+            background: #fff; border: 2px solid #206694; border-radius: 8px;
             padding: 24px; margin-top: 20px; box-shadow: 0 2px 8px rgba(0,0,0,0.1); 
         }
         .service-analysis h2 { 
@@ -40,7 +44,10 @@
 <body>
     <h1 style="text-align: center;">South Shields Metro Departures</h1>
     
-    <div id="predicted-departure">Predicted next departure time: <span id="prediction-time">Loading...</span></div>
+    <div id="predicted-departure" aria-live="polite">
+        <span id="status-label" class="sr-only">Scheduled</span>
+        Predicted next departure time: <span id="prediction-time">Loading...</span>
+    </div>
     
     <div class="card">
         <h2>Next Scheduled Times</h2>
@@ -48,7 +55,11 @@
     </div>
     
     <div class="service-analysis">
-        <h2><span class="status-indicator status-info" id="statusIndicator"></span>Next scheduled Departure:</h2>
+        <h2>
+            <span class="status-indicator status-info" id="statusIndicator" aria-hidden="true"></span>
+            <span id="indicator-text" class="sr-only">Scheduled</span>
+            Next scheduled Departure:
+        </h2>
         <div id="analysisContent" class="analysis-content">Loading...</div>
         <div class="analysis-timestamp" id="analysisTimestamp"></div>
     </div>
@@ -81,7 +92,7 @@
             const schedule = getScheduleForDay();
             let upcomingTimes = [];
             if (schedule[currentHour]) {
-                const validMinutes = schedule[currentHour].filter(m => m > currentMinute);
+                const validMinutes = schedule[currentHour].filter(m => m >= currentMinute);
                 upcomingTimes.push(...validMinutes.map(m => ({hour: currentHour, minute: m})));
             }
             let hour = currentHour + 1;
@@ -116,18 +127,21 @@
         async function fetchPrediction() {
             const data = await fetchLiveData('/api/times/CHI/2');
             const predictionSpan = document.getElementById('prediction-time');
+            const statusLabel = document.getElementById('status-label');
             
             if (data && data.length > 0) {
                 const now = new Date();
                 const predictedTime = new Date(now.getTime() + (data[0].dueIn - 2) * 60000);
                 predictionSpan.textContent = `${predictedTime.getHours().toString().padStart(2,'0')}:${predictedTime.getMinutes().toString().padStart(2,'0')}`;
-                predictionSpan.parentElement.style.background = '#27ae60'; // Green when live
+                predictionSpan.parentElement.style.background = '#1b7a43'; // WCAG Green
+                statusLabel.textContent = 'Live';
             } else {
                 const nextTimes = getNextScheduledTimes();
                 predictionSpan.textContent = nextTimes.length > 0 
                     ? `${nextTimes[0].hour.toString().padStart(2,'0')}:${nextTimes[0].minute.toString().padStart(2,'0')}`
                     : 'No departures';
-                predictionSpan.parentElement.style.background = '#3498db'; // Blue when static
+                predictionSpan.parentElement.style.background = '#206694'; // WCAG Blue
+                statusLabel.textContent = 'Scheduled';
             }
         }
 
@@ -136,16 +150,20 @@
             const nextScheduled = getNextScheduledTimes();
             const analysisContent = document.getElementById('analysisContent');
             const statusIndicator = document.getElementById('statusIndicator');
+            const indicatorText = document.getElementById('indicator-text');
             const timestampDiv = document.getElementById('analysisTimestamp');
 
             if (nextScheduled.length === 0) {
                 analysisContent.textContent = 'Service has ended for the day.';
                 statusIndicator.className = 'status-indicator status-info';
+                indicatorText.textContent = 'Information';
             } else {
                 const next = nextScheduled[0];
                 const minsUntil = next.hour * 60 + next.minute - (now.getHours() * 60 + now.getMinutes());
-                analysisContent.textContent = `${next.hour.toString().padStart(2,'0')}:${next.minute.toString().padStart(2,'0')} (${minsUntil} mins)`;
+                const timeStr = minsUntil === 0 ? 'Due now' : `${minsUntil} ${minsUntil === 1 ? 'min' : 'mins'}`;
+                analysisContent.textContent = `${next.hour.toString().padStart(2,'0')}:${next.minute.toString().padStart(2,'0')} (${timeStr})`;
                 statusIndicator.className = 'status-indicator status-info';
+                indicatorText.textContent = 'Scheduled';
             }
             
             timestampDiv.textContent = `Updated: ${now.toLocaleTimeString('en-GB')}`;


### PR DESCRIPTION
💡 What:
- Added `.sr-only` utility for accessible text.
- Implemented 'Due now' state for departures at the current minute.
- Handled singular/plural minutes for countdowns.
- Updated background colors to WCAG-compliant shades (#1b7a43 for Live, #206694 for Scheduled).
- Added `aria-live="polite"` and hidden labels to communicate status to screen readers.
- Adjusted schedule filter to be inclusive of the current minute.

🎯 Why:
- The interface lacked clear status labels for non-visual users.
- Color contrast was insufficient for accessibility standards.
- Trains disappearing exactly when they were due caused confusion.
- '0 mins' was less intuitive than 'Due now'.

📸 Before/After:
- Before: Light blue/green backgrounds, no status text, '0 mins' display.
- After: Accessible contrast colors, screen-reader friendly labels, 'Due now' micro-copy.

♿ Accessibility:
- Full screen reader support for live/scheduled status changes.
- Improved color contrast (WCAG AA).
- Clearer semantic updates via aria-live.

---
*PR created automatically by Jules for task [7432176741366125963](https://jules.google.com/task/7432176741366125963) started by @ColinPattinson*