### PR TITLE
🎨 Palette: Accessible departures and 'Due now' states

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-05-15 - Screen Reader Context Pattern
+**Learning:** For status indicators that rely on visual-only cues (like background color or colored dots), using a sibling `.sr-only` span that updates its text content alongside the visual state ensures that assistive technology users receive the same information as sighted users without visual clutter.
+**Action:** Always pair visual status indicators (e.g., #statusIndicator) with an adjacent `.sr-only` element (e.g., #indicator-text) and update both simultaneously in the UI logic.

--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
     <style>
         body { font-family: Arial, sans-serif; margin: 20px; }
         #predicted-departure {
-            background: #3498db; color: white; padding: 20px; border-radius: 8px; 
+            background: #206694; color: white; padding: 20px; border-radius: 8px;
             margin: 20px 0; font-size: 2em; text-align: center;
         }
         .card { 
@@ -15,7 +15,7 @@
             max-width: 600px; margin-left: auto; margin-right: auto;
         }
         .service-analysis { 
-            background: #fff; border: 2px solid #3498db; border-radius: 8px; 
+            background: #fff; border: 2px solid #206694; border-radius: 8px;
             padding: 24px; margin-top: 20px; box-shadow: 0 2px 8px rgba(0,0,0,0.1); 
         }
         .service-analysis h2 { 
@@ -23,10 +23,10 @@
             display: flex; align-items: center; gap: 10px; 
         }
         .status-indicator { width: 12px; height: 12px; border-radius: 50%; display: inline-block; }
-        .status-good { background-color: #27ae60; }
+        .status-good { background-color: #1b7a43; }
         .status-warning { background-color: #f39c12; }
         .status-error { background-color: #e74c3c; }
-        .status-info { background-color: #3498db; }
+        .status-info { background-color: #206694; }
         .analysis-content { color: #2c3e50; line-height: 1.6; font-size: 1.2em; font-weight: 500; }
         .analysis-timestamp { color: #7f8c8d; font-size: 0.9em; margin-top: 12px; padding-top: 12px; border-top: 1px solid #ecf0f1; }
         #scheduled-times { font-size: 1.4em; line-height: 1.8; }
@@ -35,12 +35,26 @@
             padding: 16px; margin-top: 20px; font-size: 0.95em; color: #856404; 
             text-align: center;
         }
+        .sr-only {
+            position: absolute;
+            width: 1px;
+            height: 1px;
+            padding: 0;
+            margin: -1px;
+            overflow: hidden;
+            clip: rect(0, 0, 0, 0);
+            white-space: nowrap;
+            border-width: 0;
+        }
     </style>
 </head>
 <body>
     <h1 style="text-align: center;">South Shields Metro Departures</h1>
     
-    <div id="predicted-departure">Predicted next departure time: <span id="prediction-time">Loading...</span></div>
+    <div id="predicted-departure" aria-live="polite">
+        <span id="status-label" class="sr-only"></span>
+        Predicted next departure time: <span id="prediction-time">Loading...</span>
+    </div>
     
     <div class="card">
         <h2>Next Scheduled Times</h2>
@@ -48,7 +62,11 @@
     </div>
     
     <div class="service-analysis">
-        <h2><span class="status-indicator status-info" id="statusIndicator"></span>Next scheduled Departure:</h2>
+        <h2>
+            <span class="status-indicator status-info" id="statusIndicator" aria-hidden="true"></span>
+            <span id="indicator-text" class="sr-only"></span>
+            Next scheduled Departure:
+        </h2>
         <div id="analysisContent" class="analysis-content">Loading...</div>
         <div class="analysis-timestamp" id="analysisTimestamp"></div>
     </div>
@@ -81,7 +99,7 @@
             const schedule = getScheduleForDay();
             let upcomingTimes = [];
             if (schedule[currentHour]) {
-                const validMinutes = schedule[currentHour].filter(m => m > currentMinute);
+                const validMinutes = schedule[currentHour].filter(m => m >= currentMinute);
                 upcomingTimes.push(...validMinutes.map(m => ({hour: currentHour, minute: m})));
             }
             let hour = currentHour + 1;
@@ -116,18 +134,21 @@
         async function fetchPrediction() {
             const data = await fetchLiveData('/api/times/CHI/2');
             const predictionSpan = document.getElementById('prediction-time');
+            const statusLabel = document.getElementById('status-label');
             
             if (data && data.length > 0) {
                 const now = new Date();
                 const predictedTime = new Date(now.getTime() + (data[0].dueIn - 2) * 60000);
                 predictionSpan.textContent = `${predictedTime.getHours().toString().padStart(2,'0')}:${predictedTime.getMinutes().toString().padStart(2,'0')}`;
-                predictionSpan.parentElement.style.background = '#27ae60'; // Green when live
+                predictionSpan.parentElement.style.background = '#1b7a43'; // Green when live
+                statusLabel.textContent = 'Live prediction: ';
             } else {
                 const nextTimes = getNextScheduledTimes();
                 predictionSpan.textContent = nextTimes.length > 0 
                     ? `${nextTimes[0].hour.toString().padStart(2,'0')}:${nextTimes[0].minute.toString().padStart(2,'0')}`
                     : 'No departures';
-                predictionSpan.parentElement.style.background = '#3498db'; // Blue when static
+                predictionSpan.parentElement.style.background = '#206694'; // Blue when static
+                statusLabel.textContent = 'Scheduled departure: ';
             }
         }
 
@@ -136,16 +157,26 @@
             const nextScheduled = getNextScheduledTimes();
             const analysisContent = document.getElementById('analysisContent');
             const statusIndicator = document.getElementById('statusIndicator');
+            const indicatorText = document.getElementById('indicator-text');
             const timestampDiv = document.getElementById('analysisTimestamp');
 
             if (nextScheduled.length === 0) {
                 analysisContent.textContent = 'Service has ended for the day.';
                 statusIndicator.className = 'status-indicator status-info';
+                indicatorText.textContent = 'Information: ';
             } else {
                 const next = nextScheduled[0];
                 const minsUntil = next.hour * 60 + next.minute - (now.getHours() * 60 + now.getMinutes());
-                analysisContent.textContent = `${next.hour.toString().padStart(2,'0')}:${next.minute.toString().padStart(2,'0')} (${minsUntil} mins)`;
+
+                let timeStr = `${next.hour.toString().padStart(2,'0')}:${next.minute.toString().padStart(2,'0')}`;
+                if (minsUntil === 0) {
+                    analysisContent.textContent = `${timeStr} (Due now)`;
+                } else {
+                    analysisContent.textContent = `${timeStr} (${minsUntil} ${minsUntil === 1 ? 'min' : 'mins'})`;
+                }
+
                 statusIndicator.className = 'status-indicator status-info';
+                indicatorText.textContent = 'Service status: ';
             }
             
             timestampDiv.textContent = `Updated: ${now.toLocaleTimeString('en-GB')}`;


### PR DESCRIPTION
💡 **What**: Improved the departure board's accessibility and clarity by implementing WCAG-compliant colors, ARIA live regions, and refined 'Due now' logic.

🎯 **Why**: The original interface lacked sufficient color contrast and provided no context for screen readers when the status changed from scheduled to live. Additionally, departures occurring in the current minute were being filtered out, leading to a "Loading..." or empty state when a train was actually due.

📸 **Before/After**: 
- Before: Light blue (#3498db) and green (#27ae60) used for states. Departures in the current minute were hidden.
- After: Darker, accessible blue (#206694) and green (#1b7a43). "Due now" displayed for current-minute departures.

♿ **Accessibility**:
- Added `.sr-only` class for screen-reader-only text.
- Added `aria-live="polite"` to the main departure display.
- Implemented "Screen Reader Context Pattern" to announce "Live prediction" or "Scheduled departure" when the background color changes.
- Decorative status dots are now `aria-hidden="true"` with sibling accessible labels.

---
*PR created automatically by Jules for task [3599663866139827975](https://jules.google.com/task/3599663866139827975) started by @ColinPattinson*