### PR TITLE
🎨 Palette: Enhance departure display accessibility and timing

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,7 @@
+## 2026-06-04 - Screen Reader Context Pattern
+**Learning:** Color-coded status (e.g., Live vs. Scheduled) is invisible to screen reader and color-blind users unless paired with text. Using `aria-live` on a container with a visually hidden `sr-only` label allows for accessible status updates without cluttering the visual UI.
+**Action:** Always include a visually hidden status label when using color to communicate state changes, and use `aria-live="polite"` for dynamic updates.
+
+## 2026-06-04 - Schedule Filtering Dead Zones
+**Learning:** Using exclusive filtering (e.g., `m > currentMinute`) for upcoming events creates a 60-second 'dead zone' where events happening within the current minute are hidden, even if they are still relevant (e.g., "Due now").
+**Action:** Use inclusive checks (e.g., `m >= currentMinute`) for time-based filtering and implement a "Due now" state for zero-minute countdowns.

--- a/index.html
+++ b/index.html
@@ -15,7 +15,7 @@
             max-width: 600px; margin-left: auto; margin-right: auto;
         }
         .service-analysis { 
-            background: #fff; border: 2px solid #3498db; border-radius: 8px; 
+            background: #fff; border: 2px solid #206694; border-radius: 8px;
             padding: 24px; margin-top: 20px; box-shadow: 0 2px 8px rgba(0,0,0,0.1); 
         }
         .service-analysis h2 { 
@@ -35,12 +35,19 @@
             padding: 16px; margin-top: 20px; font-size: 0.95em; color: #856404; 
             text-align: center;
         }
+        .sr-only {
+            position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px;
+            overflow: hidden; clip: rect(0, 0, 0, 0); white-space: nowrap; border-width: 0;
+        }
     </style>
 </head>
 <body>
     <h1 style="text-align: center;">South Shields Metro Departures</h1>
     
-    <div id="predicted-departure">Predicted next departure time: <span id="prediction-time">Loading...</span></div>
+    <div id="predicted-departure" aria-live="polite">
+        <span id="status-label" class="sr-only">Status:</span>
+        Predicted next departure time: <span id="prediction-time">Loading...</span>
+    </div>
     
     <div class="card">
         <h2>Next Scheduled Times</h2>
@@ -81,7 +88,7 @@
             const schedule = getScheduleForDay();
             let upcomingTimes = [];
             if (schedule[currentHour]) {
-                const validMinutes = schedule[currentHour].filter(m => m > currentMinute);
+                const validMinutes = schedule[currentHour].filter(m => m >= currentMinute);
                 upcomingTimes.push(...validMinutes.map(m => ({hour: currentHour, minute: m})));
             }
             let hour = currentHour + 1;
@@ -116,18 +123,21 @@
         async function fetchPrediction() {
             const data = await fetchLiveData('/api/times/CHI/2');
             const predictionSpan = document.getElementById('prediction-time');
+            const statusLabel = document.getElementById('status-label');
             
             if (data && data.length > 0) {
                 const now = new Date();
                 const predictedTime = new Date(now.getTime() + (data[0].dueIn - 2) * 60000);
                 predictionSpan.textContent = `${predictedTime.getHours().toString().padStart(2,'0')}:${predictedTime.getMinutes().toString().padStart(2,'0')}`;
-                predictionSpan.parentElement.style.background = '#27ae60'; // Green when live
+                predictionSpan.parentElement.style.background = '#1b7a43'; // WCAG Green when live
+                statusLabel.textContent = 'Live prediction: ';
             } else {
                 const nextTimes = getNextScheduledTimes();
                 predictionSpan.textContent = nextTimes.length > 0 
                     ? `${nextTimes[0].hour.toString().padStart(2,'0')}:${nextTimes[0].minute.toString().padStart(2,'0')}`
                     : 'No departures';
-                predictionSpan.parentElement.style.background = '#3498db'; // Blue when static
+                predictionSpan.parentElement.style.background = '#206694'; // WCAG Blue when static
+                statusLabel.textContent = 'Scheduled departure: ';
             }
         }
 
@@ -144,7 +154,8 @@
             } else {
                 const next = nextScheduled[0];
                 const minsUntil = next.hour * 60 + next.minute - (now.getHours() * 60 + now.getMinutes());
-                analysisContent.textContent = `${next.hour.toString().padStart(2,'0')}:${next.minute.toString().padStart(2,'0')} (${minsUntil} mins)`;
+                const timeStr = minsUntil === 0 ? 'Due now' : `${minsUntil} ${minsUntil === 1 ? 'min' : 'mins'}`;
+                analysisContent.textContent = `${next.hour.toString().padStart(2,'0')}:${next.minute.toString().padStart(2,'0')} (${timeStr})`;
                 statusIndicator.className = 'status-indicator status-info';
             }
             


### PR DESCRIPTION
💡 **What**: Enhanced the Metro departures interface with better accessibility and more precise timing logic.
- Added `aria-live="polite"` and a visually hidden `#status-label` to ensure screen reader users receive updates and context (Live vs. Scheduled).
- Updated background colors and borders to WCAG AA/AAA compliant contrast ratios.
- Improved `getNextScheduledTimes` logic to be inclusive of the current minute, eliminating a 60-second "dead zone".
- Added "Due now" state and correct pluralization ("1 min" vs "2 mins") for a more polished experience.

🎯 **Why**: The previous version relied solely on color to communicate status, violating accessibility guidelines. It also failed to show trains due in the current minute, which are the most critical for users.

♿ **Accessibility**: 
- Screen readers now announce departure updates automatically.
- Status (Live/Scheduled) is now explicitly labeled for assistive technology.
- Color contrast meets standard accessibility requirements.

---
*PR created automatically by Jules for task [15566548042748162442](https://jules.google.com/task/15566548042748162442) started by @ColinPattinson*