### PR TITLE
🎨 Palette: Enhance departure accessibility and timing logic

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-06-05 - Improving Departure Clarity and Accessibility
+**Learning:** The application used color alone (green/blue) to distinguish between 'Live' and 'Scheduled' departures, which is inaccessible to color-blind users and screen readers. Additionally, a strict greater-than comparison on minutes created a 60-second 'dead zone' where upcoming departures were hidden until they actually passed.
+**Action:** Always use a 'Screen Reader Context Pattern' (visually hidden text inside an aria-live region) to communicate state changes that are otherwise only visual. Use inclusive comparisons (>=) for time-based filtering to ensure 'Due now' states are correctly captured.

--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
     <style>
         body { font-family: Arial, sans-serif; margin: 20px; }
         #predicted-departure {
-            background: #3498db; color: white; padding: 20px; border-radius: 8px; 
+            background: #206694; color: white; padding: 20px; border-radius: 8px;
             margin: 20px 0; font-size: 2em; text-align: center;
         }
         .card { 
@@ -15,7 +15,7 @@
             max-width: 600px; margin-left: auto; margin-right: auto;
         }
         .service-analysis { 
-            background: #fff; border: 2px solid #3498db; border-radius: 8px; 
+            background: #fff; border: 2px solid #206694; border-radius: 8px;
             padding: 24px; margin-top: 20px; box-shadow: 0 2px 8px rgba(0,0,0,0.1); 
         }
         .service-analysis h2 { 
@@ -26,7 +26,8 @@
         .status-good { background-color: #27ae60; }
         .status-warning { background-color: #f39c12; }
         .status-error { background-color: #e74c3c; }
-        .status-info { background-color: #3498db; }
+        .status-info { background-color: #206694; }
+        .sr-only { position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px; overflow: hidden; clip: rect(0, 0, 0, 0); white-space: nowrap; border-width: 0; }
         .analysis-content { color: #2c3e50; line-height: 1.6; font-size: 1.2em; font-weight: 500; }
         .analysis-timestamp { color: #7f8c8d; font-size: 0.9em; margin-top: 12px; padding-top: 12px; border-top: 1px solid #ecf0f1; }
         #scheduled-times { font-size: 1.4em; line-height: 1.8; }
@@ -40,7 +41,10 @@
 <body>
     <h1 style="text-align: center;">South Shields Metro Departures</h1>
     
-    <div id="predicted-departure">Predicted next departure time: <span id="prediction-time">Loading...</span></div>
+    <div id="predicted-departure" aria-live="polite">
+        <span id="status-label" class="sr-only">Checking status...</span>
+        Predicted next departure time: <span id="prediction-time">Loading...</span>
+    </div>
     
     <div class="card">
         <h2>Next Scheduled Times</h2>
@@ -81,7 +85,7 @@
             const schedule = getScheduleForDay();
             let upcomingTimes = [];
             if (schedule[currentHour]) {
-                const validMinutes = schedule[currentHour].filter(m => m > currentMinute);
+                const validMinutes = schedule[currentHour].filter(m => m >= currentMinute);
                 upcomingTimes.push(...validMinutes.map(m => ({hour: currentHour, minute: m})));
             }
             let hour = currentHour + 1;
@@ -117,17 +121,20 @@
             const data = await fetchLiveData('/api/times/CHI/2');
             const predictionSpan = document.getElementById('prediction-time');
             
+            const statusLabel = document.getElementById('status-label');
             if (data && data.length > 0) {
                 const now = new Date();
                 const predictedTime = new Date(now.getTime() + (data[0].dueIn - 2) * 60000);
                 predictionSpan.textContent = `${predictedTime.getHours().toString().padStart(2,'0')}:${predictedTime.getMinutes().toString().padStart(2,'0')}`;
-                predictionSpan.parentElement.style.background = '#27ae60'; // Green when live
+                predictionSpan.parentElement.style.background = '#1b7a43'; // Green when live
+                statusLabel.textContent = 'Live departure: ';
             } else {
                 const nextTimes = getNextScheduledTimes();
                 predictionSpan.textContent = nextTimes.length > 0 
                     ? `${nextTimes[0].hour.toString().padStart(2,'0')}:${nextTimes[0].minute.toString().padStart(2,'0')}`
                     : 'No departures';
-                predictionSpan.parentElement.style.background = '#3498db'; // Blue when static
+                predictionSpan.parentElement.style.background = '#206694'; // Blue when static
+                statusLabel.textContent = 'Scheduled departure: ';
             }
         }
 
@@ -143,8 +150,16 @@
                 statusIndicator.className = 'status-indicator status-info';
             } else {
                 const next = nextScheduled[0];
-                const minsUntil = next.hour * 60 + next.minute - (now.getHours() * 60 + now.getMinutes());
-                analysisContent.textContent = `${next.hour.toString().padStart(2,'0')}:${next.minute.toString().padStart(2,'0')} (${minsUntil} mins)`;
+                const minsUntil = (next.hour * 60 + next.minute) - (now.getHours() * 60 + now.getMinutes());
+                let timeString = `${next.hour.toString().padStart(2,'0')}:${next.minute.toString().padStart(2,'0')}`;
+
+                if (minsUntil === 0) {
+                    timeString += ' (Due now)';
+                } else {
+                    timeString += ` (${minsUntil} ${minsUntil === 1 ? 'min' : 'mins'})`;
+                }
+
+                analysisContent.textContent = timeString;
                 statusIndicator.className = 'status-indicator status-info';
             }
             


### PR DESCRIPTION
💡 What: This PR enhances the departure display by improving color contrast, adding screen reader support, and fixing edge-case timing logic.

🎯 Why: 
1. The previous brand colors did not meet WCAG AA contrast standards.
2. The distinction between 'Live' and 'Scheduled' was only visual.
3. Departures within the current minute were being filtered out, making them disappear just before they arrived.

📸 Before/After: 
- Live: From #27ae60 to #1b7a43 (Compliant green)
- Scheduled: From #3498db to #206694 (Compliant blue)
- Timing: "0 mins" changed to "Due now", "1 mins" changed to "1 min".

♿ Accessibility:
- Added `aria-live="polite"` to the main prediction container.
- Added `.sr-only` labels to explicitly announce "Live departure" vs "Scheduled departure".
- Increased color contrast to 4.5:1+ for all text.

---
*PR created automatically by Jules for task [13152507413012061423](https://jules.google.com/task/13152507413012061423) started by @ColinPattinson*