### PR TITLE
🎨 Palette: Enhance accessibility and micro-UX of departures

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,8 @@
+
+## 2024-06-07 - Screen Reader Context Pattern for Color-Coded Status
+**Learning:** When using color (like Green for 'Live' and Blue for 'Scheduled') to communicate application state, screen reader users miss this context unless it's explicitly provided in text. Using a visually hidden (.sr-only) label within an aria-live container allows for immediate and accessible state announcements without altering the visual design.
+**Action:** Always pair visual state indicators (colors, icons) with a .sr-only text equivalent and consider aria-live="polite" for dynamic updates.
+
+## 2024-06-07 - Addressing the Time 'Dead Zone' in Transit UIs
+**Learning:** A strictly greater-than check (m > currentMinute) for departure times creates a 60-second 'dead zone' where a train departing *now* is hidden from the UI. An inclusive check (m >= currentMinute) combined with a "Due now" label provides much better user clarity for immediate departures.
+**Action:** Use inclusive boundaries for time-based filtering and provide specific "Due now" feedback for zero-minute countdowns.

--- a/index.html
+++ b/index.html
@@ -15,7 +15,7 @@
             max-width: 600px; margin-left: auto; margin-right: auto;
         }
         .service-analysis { 
-            background: #fff; border: 2px solid #3498db; border-radius: 8px; 
+            background: #fff; border: 2px solid #206694; border-radius: 8px;
             padding: 24px; margin-top: 20px; box-shadow: 0 2px 8px rgba(0,0,0,0.1); 
         }
         .service-analysis h2 { 
@@ -23,10 +23,10 @@
             display: flex; align-items: center; gap: 10px; 
         }
         .status-indicator { width: 12px; height: 12px; border-radius: 50%; display: inline-block; }
-        .status-good { background-color: #27ae60; }
+        .status-good { background-color: #1b7a43; }
         .status-warning { background-color: #f39c12; }
         .status-error { background-color: #e74c3c; }
-        .status-info { background-color: #3498db; }
+        .status-info { background-color: #206694; }
         .analysis-content { color: #2c3e50; line-height: 1.6; font-size: 1.2em; font-weight: 500; }
         .analysis-timestamp { color: #7f8c8d; font-size: 0.9em; margin-top: 12px; padding-top: 12px; border-top: 1px solid #ecf0f1; }
         #scheduled-times { font-size: 1.4em; line-height: 1.8; }
@@ -35,12 +35,19 @@
             padding: 16px; margin-top: 20px; font-size: 0.95em; color: #856404; 
             text-align: center;
         }
+        .sr-only {
+            position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px;
+            overflow: hidden; clip: rect(0, 0, 0, 0); white-space: nowrap; border: 0;
+        }
     </style>
 </head>
 <body>
     <h1 style="text-align: center;">South Shields Metro Departures</h1>
     
-    <div id="predicted-departure">Predicted next departure time: <span id="prediction-time">Loading...</span></div>
+    <div id="predicted-departure" aria-live="polite">
+        <span id="status-label" class="sr-only"></span>
+        Predicted next departure time: <span id="prediction-time">Loading...</span>
+    </div>
     
     <div class="card">
         <h2>Next Scheduled Times</h2>
@@ -48,7 +55,11 @@
     </div>
     
     <div class="service-analysis">
-        <h2><span class="status-indicator status-info" id="statusIndicator"></span>Next scheduled Departure:</h2>
+        <h2>
+            <span class="status-indicator status-info" id="statusIndicator" aria-hidden="true"></span>
+            <span id="indicator-text" class="sr-only"></span>
+            Next scheduled Departure:
+        </h2>
         <div id="analysisContent" class="analysis-content">Loading...</div>
         <div class="analysis-timestamp" id="analysisTimestamp"></div>
     </div>
@@ -81,7 +92,7 @@
             const schedule = getScheduleForDay();
             let upcomingTimes = [];
             if (schedule[currentHour]) {
-                const validMinutes = schedule[currentHour].filter(m => m > currentMinute);
+                const validMinutes = schedule[currentHour].filter(m => m >= currentMinute);
                 upcomingTimes.push(...validMinutes.map(m => ({hour: currentHour, minute: m})));
             }
             let hour = currentHour + 1;
@@ -116,18 +127,21 @@
         async function fetchPrediction() {
             const data = await fetchLiveData('/api/times/CHI/2');
             const predictionSpan = document.getElementById('prediction-time');
+            const statusLabel = document.getElementById('status-label');
             
             if (data && data.length > 0) {
                 const now = new Date();
                 const predictedTime = new Date(now.getTime() + (data[0].dueIn - 2) * 60000);
                 predictionSpan.textContent = `${predictedTime.getHours().toString().padStart(2,'0')}:${predictedTime.getMinutes().toString().padStart(2,'0')}`;
-                predictionSpan.parentElement.style.background = '#27ae60'; // Green when live
+                predictionSpan.parentElement.style.background = '#1b7a43'; // Green when live
+                statusLabel.textContent = 'Live: ';
             } else {
                 const nextTimes = getNextScheduledTimes();
                 predictionSpan.textContent = nextTimes.length > 0 
                     ? `${nextTimes[0].hour.toString().padStart(2,'0')}:${nextTimes[0].minute.toString().padStart(2,'0')}`
                     : 'No departures';
-                predictionSpan.parentElement.style.background = '#3498db'; // Blue when static
+                predictionSpan.parentElement.style.background = '#206694'; // Blue when static
+                statusLabel.textContent = 'Scheduled: ';
             }
         }
 
@@ -136,16 +150,22 @@
             const nextScheduled = getNextScheduledTimes();
             const analysisContent = document.getElementById('analysisContent');
             const statusIndicator = document.getElementById('statusIndicator');
+            const indicatorText = document.getElementById('indicator-text');
             const timestampDiv = document.getElementById('analysisTimestamp');
 
             if (nextScheduled.length === 0) {
                 analysisContent.textContent = 'Service has ended for the day.';
                 statusIndicator.className = 'status-indicator status-info';
+                indicatorText.textContent = 'Service ended';
             } else {
                 const next = nextScheduled[0];
                 const minsUntil = next.hour * 60 + next.minute - (now.getHours() * 60 + now.getMinutes());
-                analysisContent.textContent = `${next.hour.toString().padStart(2,'0')}:${next.minute.toString().padStart(2,'0')} (${minsUntil} mins)`;
+                const timeStr = `${next.hour.toString().padStart(2,'0')}:${next.minute.toString().padStart(2,'0')}`;
+                const countdownStr = minsUntil === 0 ? 'Due now' : `${minsUntil} ${minsUntil === 1 ? 'min' : 'mins'}`;
+
+                analysisContent.textContent = `${timeStr} (${countdownStr})`;
                 statusIndicator.className = 'status-indicator status-info';
+                indicatorText.textContent = 'Scheduled';
             }
             
             timestampDiv.textContent = `Updated: ${now.toLocaleTimeString('en-GB')}`;


### PR DESCRIPTION
### 💡 What: The UX enhancement added
This PR introduces several micro-UX and accessibility improvements to the South Shields Metro Departures interface. It focuses on making the "Live vs. Scheduled" status accessible to screen readers, improving color contrast, and refining the countdown logic.

### 🎯 Why: The user problem it solves
1.  **Accessibility Gap:** The distinction between Live and Scheduled data was previously only communicated via color, which is inaccessible to blind or color-blind users.
2.  **Information Accuracy:** A bug in the scheduling logic caused departures occurring within the current minute to be hidden, creating a confusing "dead zone."
3.  **Micro-UX:** Countdown text now uses proper pluralization ("1 min" vs "2 mins") and a clearer "Due now" state for immediate departures.
4.  **WCAG Compliance:** The original colors were darkened to meet AA contrast standards.

### ♿ Accessibility improvements
- Added `aria-live="polite"` to the main departure container to announce updates.
- Used the "Screen Reader Context Pattern" (.sr-only labels) to provide text equivalents for color-coded statuses.
- Increased color contrast for both Live (Green) and Scheduled (Blue) states.
- Marked decorative status indicators with `aria-hidden="true"`.

### 📸 Before/After
- **Before:** Light green/blue backgrounds; no screen reader announcement for status; "0 mins" displayed for immediate trains; trains in the current minute were hidden.
- **After:** Darker, WCAG-compliant backgrounds; "Live:" or "Scheduled:" announced by screen readers; "Due now" displayed for immediate trains; trains in the current minute are correctly listed.

---
*PR created automatically by Jules for task [2275694615034969595](https://jules.google.com/task/2275694615034969595) started by @ColinPattinson*