### PR TITLE
🎨 Palette: Accessible Departure Status & Semantic Lists

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-06-20 - Accessible Status Indicators
+**Learning:** Visual-only status indicators (like background colors or dots) are inaccessible to screen reader and color-blind users. Combining them with visually hidden (`.sr-only`) text labels and `aria-live` ensures that all users receive the same state information.
+**Action:** Always pair color-coded states with an `.sr-only` description and use `aria-live="polite"` for dynamic updates to these states.

--- a/index.html
+++ b/index.html
@@ -15,7 +15,7 @@
             max-width: 600px; margin-left: auto; margin-right: auto;
         }
         .service-analysis { 
-            background: #fff; border: 2px solid #3498db; border-radius: 8px; 
+            background: #fff; border: 2px solid #206694; border-radius: 8px;
             padding: 24px; margin-top: 20px; box-shadow: 0 2px 8px rgba(0,0,0,0.1); 
         }
         .service-analysis h2 { 
@@ -23,13 +23,18 @@
             display: flex; align-items: center; gap: 10px; 
         }
         .status-indicator { width: 12px; height: 12px; border-radius: 50%; display: inline-block; }
-        .status-good { background-color: #27ae60; }
+        .status-good, .is-live { background-color: #1b7a43 !important; }
         .status-warning { background-color: #f39c12; }
         .status-error { background-color: #e74c3c; }
-        .status-info { background-color: #3498db; }
+        .status-info, .is-scheduled { background-color: #206694 !important; }
         .analysis-content { color: #2c3e50; line-height: 1.6; font-size: 1.2em; font-weight: 500; }
         .analysis-timestamp { color: #7f8c8d; font-size: 0.9em; margin-top: 12px; padding-top: 12px; border-top: 1px solid #ecf0f1; }
         #scheduled-times { font-size: 1.4em; line-height: 1.8; }
+        #scheduled-times ul { list-style: none; padding: 0; margin: 0; }
+        .sr-only {
+            position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px;
+            overflow: hidden; clip: rect(0, 0, 0, 0); border: 0;
+        }
         .static-note { 
             background: #fff3cd; border: 1px solid #ffeaa7; border-radius: 8px; 
             padding: 16px; margin-top: 20px; font-size: 0.95em; color: #856404; 
@@ -40,7 +45,10 @@
 <body>
     <h1 style="text-align: center;">South Shields Metro Departures</h1>
     
-    <div id="predicted-departure">Predicted next departure time: <span id="prediction-time">Loading...</span></div>
+    <div id="predicted-departure" aria-live="polite">
+        <span id="status-label" class="sr-only"></span>
+        Predicted next departure time: <span id="prediction-time">Loading...</span>
+    </div>
     
     <div class="card">
         <h2>Next Scheduled Times</h2>
@@ -48,7 +56,11 @@
     </div>
     
     <div class="service-analysis">
-        <h2><span class="status-indicator status-info" id="statusIndicator"></span>Next scheduled Departure:</h2>
+        <h2>
+            <span class="status-indicator status-info" id="statusIndicator"></span>
+            <span id="indicator-text" class="sr-only"></span>
+            Next scheduled Departure:
+        </h2>
         <div id="analysisContent" class="analysis-content">Loading...</div>
         <div class="analysis-timestamp" id="analysisTimestamp"></div>
     </div>
@@ -97,9 +109,12 @@
         function displayScheduledTimes() {
             const scheduledDiv = document.getElementById('scheduled-times');
             const nextTimes = getNextScheduledTimes();
-            scheduledDiv.innerHTML = nextTimes.length > 0 
-                ? nextTimes.map(t => `${t.hour.toString().padStart(2,'0')}:${t.minute.toString().padStart(2,'0')}`).join('<br>')
-                : 'No more scheduled departures today';
+            if (nextTimes.length > 0) {
+                const listItems = nextTimes.map(t => `<li>${t.hour.toString().padStart(2,'0')}:${t.minute.toString().padStart(2,'0')}</li>`).join('');
+                scheduledDiv.innerHTML = `<ul>${listItems}</ul>`;
+            } else {
+                scheduledDiv.innerHTML = 'No more scheduled departures today';
+            }
         }
 
         async function fetchLiveData(endpoint) {
@@ -116,18 +131,24 @@
         async function fetchPrediction() {
             const data = await fetchLiveData('/api/times/CHI/2');
             const predictionSpan = document.getElementById('prediction-time');
+            const statusLabel = document.getElementById('status-label');
+            const container = predictionSpan.parentElement;
             
             if (data && data.length > 0) {
                 const now = new Date();
                 const predictedTime = new Date(now.getTime() + (data[0].dueIn - 2) * 60000);
                 predictionSpan.textContent = `${predictedTime.getHours().toString().padStart(2,'0')}:${predictedTime.getMinutes().toString().padStart(2,'0')}`;
-                predictionSpan.parentElement.style.background = '#27ae60'; // Green when live
+                statusLabel.textContent = 'Live prediction:';
+                container.classList.add('is-live');
+                container.classList.remove('is-scheduled');
             } else {
                 const nextTimes = getNextScheduledTimes();
                 predictionSpan.textContent = nextTimes.length > 0 
                     ? `${nextTimes[0].hour.toString().padStart(2,'0')}:${nextTimes[0].minute.toString().padStart(2,'0')}`
                     : 'No departures';
-                predictionSpan.parentElement.style.background = '#3498db'; // Blue when static
+                statusLabel.textContent = 'Scheduled departure:';
+                container.classList.add('is-scheduled');
+                container.classList.remove('is-live');
             }
         }
 
@@ -136,16 +157,19 @@
             const nextScheduled = getNextScheduledTimes();
             const analysisContent = document.getElementById('analysisContent');
             const statusIndicator = document.getElementById('statusIndicator');
+            const indicatorText = document.getElementById('indicator-text');
             const timestampDiv = document.getElementById('analysisTimestamp');
 
             if (nextScheduled.length === 0) {
                 analysisContent.textContent = 'Service has ended for the day.';
                 statusIndicator.className = 'status-indicator status-info';
+                indicatorText.textContent = 'Status: End of service';
             } else {
                 const next = nextScheduled[0];
                 const minsUntil = next.hour * 60 + next.minute - (now.getHours() * 60 + now.getMinutes());
-                analysisContent.textContent = `${next.hour.toString().padStart(2,'0')}:${next.minute.toString().padStart(2,'0')} (${minsUntil} mins)`;
+                analysisContent.textContent = `${next.hour.toString().padStart(2,'0')}:${next.minute.toString().padStart(2,'0')} (${minsUntil} ${minsUntil === 1 ? 'min' : 'mins'})`;
                 statusIndicator.className = 'status-indicator status-info';
+                indicatorText.textContent = 'Status: Normal';
             }
             
             timestampDiv.textContent = `Updated: ${now.toLocaleTimeString('en-GB')}`;


### PR DESCRIPTION
💡 **What:** Improved the accessibility and micro-UX of the departure board.
🎯 **Why:** The previous interface used color-only indicators for live data and non-semantic layouts for lists, making it difficult for screen-reader users to understand the state. Some colors also had insufficient contrast.
📸 **Before/After:** The primary departure banner now has a darker, compliant green/blue background and announces its status (Live/Scheduled) to screen readers. The list of times is now a properly structured list.
♿ **Accessibility:** Added `.sr-only` labels, `aria-live="polite"`, semantic HTML, and WCAG AA compliant colors.

---
*PR created automatically by Jules for task [13956370239462596360](https://jules.google.com/task/13956370239462596360) started by @ColinPattinson*