### PR TITLE
🎨 Palette: UX and Accessibility Improvements

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-06-21 - Screen Reader Context Pattern
+**Learning:** Color-coded status indicators (like green for live, blue for scheduled) are invisible to screen reader users and can be confusing for color-blind users if not supplemented with text. Using a visually hidden (.sr-only) label that updates its text alongside the visual change ensures all users receive the same state information.
+**Action:** Always pair visual-only state indicators with a .sr-only element that describes the state, and use aria-live to announce changes if they happen dynamically.

--- a/index.html
+++ b/index.html
@@ -15,7 +15,7 @@
             max-width: 600px; margin-left: auto; margin-right: auto;
         }
         .service-analysis { 
-            background: #fff; border: 2px solid #3498db; border-radius: 8px; 
+            background: #fff; border: 2px solid #206694; border-radius: 8px;
             padding: 24px; margin-top: 20px; box-shadow: 0 2px 8px rgba(0,0,0,0.1); 
         }
         .service-analysis h2 { 
@@ -23,10 +23,21 @@
             display: flex; align-items: center; gap: 10px; 
         }
         .status-indicator { width: 12px; height: 12px; border-radius: 50%; display: inline-block; }
-        .status-good { background-color: #27ae60; }
+        .status-good { background-color: #1b7a43; }
         .status-warning { background-color: #f39c12; }
         .status-error { background-color: #e74c3c; }
-        .status-info { background-color: #3498db; }
+        .status-info { background-color: #206694; }
+        .sr-only {
+            position: absolute;
+            width: 1px;
+            height: 1px;
+            padding: 0;
+            margin: -1px;
+            overflow: hidden;
+            clip: rect(0, 0, 0, 0);
+            white-space: nowrap;
+            border-width: 0;
+        }
         .analysis-content { color: #2c3e50; line-height: 1.6; font-size: 1.2em; font-weight: 500; }
         .analysis-timestamp { color: #7f8c8d; font-size: 0.9em; margin-top: 12px; padding-top: 12px; border-top: 1px solid #ecf0f1; }
         #scheduled-times { font-size: 1.4em; line-height: 1.8; }
@@ -40,7 +51,10 @@
 <body>
     <h1 style="text-align: center;">South Shields Metro Departures</h1>
     
-    <div id="predicted-departure">Predicted next departure time: <span id="prediction-time">Loading...</span></div>
+    <div id="predicted-departure" aria-live="polite">
+        <span id="status-label" class="sr-only"></span>
+        Predicted next departure time: <span id="prediction-time">Loading...</span>
+    </div>
     
     <div class="card">
         <h2>Next Scheduled Times</h2>
@@ -48,7 +62,11 @@
     </div>
     
     <div class="service-analysis">
-        <h2><span class="status-indicator status-info" id="statusIndicator"></span>Next scheduled Departure:</h2>
+        <h2>
+            <span class="status-indicator status-info" id="statusIndicator" aria-hidden="true"></span>
+            <span id="indicator-text" class="sr-only">Information:</span>
+            Next scheduled Departure:
+        </h2>
         <div id="analysisContent" class="analysis-content">Loading...</div>
         <div class="analysis-timestamp" id="analysisTimestamp"></div>
     </div>
@@ -81,7 +99,7 @@
             const schedule = getScheduleForDay();
             let upcomingTimes = [];
             if (schedule[currentHour]) {
-                const validMinutes = schedule[currentHour].filter(m => m > currentMinute);
+                const validMinutes = schedule[currentHour].filter(m => m >= currentMinute);
                 upcomingTimes.push(...validMinutes.map(m => ({hour: currentHour, minute: m})));
             }
             let hour = currentHour + 1;
@@ -116,18 +134,21 @@
         async function fetchPrediction() {
             const data = await fetchLiveData('/api/times/CHI/2');
             const predictionSpan = document.getElementById('prediction-time');
+            const statusLabel = document.getElementById('status-label');
             
             if (data && data.length > 0) {
                 const now = new Date();
                 const predictedTime = new Date(now.getTime() + (data[0].dueIn - 2) * 60000);
                 predictionSpan.textContent = `${predictedTime.getHours().toString().padStart(2,'0')}:${predictedTime.getMinutes().toString().padStart(2,'0')}`;
-                predictionSpan.parentElement.style.background = '#27ae60'; // Green when live
+                predictionSpan.parentElement.style.background = '#1b7a43'; // Green when live
+                statusLabel.textContent = 'Live prediction:';
             } else {
                 const nextTimes = getNextScheduledTimes();
                 predictionSpan.textContent = nextTimes.length > 0 
                     ? `${nextTimes[0].hour.toString().padStart(2,'0')}:${nextTimes[0].minute.toString().padStart(2,'0')}`
                     : 'No departures';
-                predictionSpan.parentElement.style.background = '#3498db'; // Blue when static
+                predictionSpan.parentElement.style.background = '#206694'; // Blue when static
+                statusLabel.textContent = 'Scheduled departure:';
             }
         }
 
@@ -136,16 +157,23 @@
             const nextScheduled = getNextScheduledTimes();
             const analysisContent = document.getElementById('analysisContent');
             const statusIndicator = document.getElementById('statusIndicator');
+            const indicatorText = document.getElementById('indicator-text');
             const timestampDiv = document.getElementById('analysisTimestamp');
 
             if (nextScheduled.length === 0) {
                 analysisContent.textContent = 'Service has ended for the day.';
                 statusIndicator.className = 'status-indicator status-info';
+                indicatorText.textContent = 'Information:';
             } else {
                 const next = nextScheduled[0];
                 const minsUntil = next.hour * 60 + next.minute - (now.getHours() * 60 + now.getMinutes());
-                analysisContent.textContent = `${next.hour.toString().padStart(2,'0')}:${next.minute.toString().padStart(2,'0')} (${minsUntil} mins)`;
+                if (minsUntil === 0) {
+                    analysisContent.textContent = `${next.hour.toString().padStart(2,'0')}:${next.minute.toString().padStart(2,'0')} (Due now)`;
+                } else {
+                    analysisContent.textContent = `${next.hour.toString().padStart(2,'0')}:${next.minute.toString().padStart(2,'0')} (${minsUntil} ${minsUntil === 1 ? 'min' : 'mins'})`;
+                }
                 statusIndicator.className = 'status-indicator status-info';
+                indicatorText.textContent = 'Scheduled:';
             }
             
             timestampDiv.textContent = `Updated: ${now.toLocaleTimeString('en-GB')}`;


### PR DESCRIPTION
💡 What:
Improved the user experience and accessibility of the South Shields Metro Departures page.

🎯 Why:
- The previous blue and green colors had insufficient contrast against white.
- Departures occurring within the current minute were being hidden (dead zone).
- Screen readers had no context for the live vs. scheduled state.
- Pluralization of "mins" was incorrect for 1 minute.

📸 Before/After:
- Blue: #3498db -> #206694
- Green: #27ae60 -> #1b7a43
- "1 mins" -> "1 min"
- "0 mins" -> "Due now"

♿ Accessibility:
- Added `aria-live="polite"` to announcement container.
- Added visually hidden labels (`#status-label`, `#indicator-text`) to provide context for screen readers.
- Improved color contrast to meet WCAG AA standards.

---
*PR created automatically by Jules for task [12859285526125901085](https://jules.google.com/task/12859285526125901085) started by @ColinPattinson*