### PR TITLE
🎨 Palette: Improve accessibility and UX of Metro Departures

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-06-22 - Screen Reader Context Pattern
+**Learning:** Visual-only indicators (like status dots or background colors) need textual equivalents for screen reader users. Using a `.sr-only` class to provide this context alongside visual updates ensures parity of information.
+**Action:** Always pair visual state changes (e.g., green/blue backgrounds, colored dots) with a visually hidden label or description that updates in sync.

--- a/index.html
+++ b/index.html
@@ -15,7 +15,7 @@
             max-width: 600px; margin-left: auto; margin-right: auto;
         }
         .service-analysis { 
-            background: #fff; border: 2px solid #3498db; border-radius: 8px; 
+            background: #fff; border: 2px solid #206694; border-radius: 8px;
             padding: 24px; margin-top: 20px; box-shadow: 0 2px 8px rgba(0,0,0,0.1); 
         }
         .service-analysis h2 { 
@@ -23,10 +23,10 @@
             display: flex; align-items: center; gap: 10px; 
         }
         .status-indicator { width: 12px; height: 12px; border-radius: 50%; display: inline-block; }
-        .status-good { background-color: #27ae60; }
+        .status-good { background-color: #1b7a43; }
         .status-warning { background-color: #f39c12; }
         .status-error { background-color: #e74c3c; }
-        .status-info { background-color: #3498db; }
+        .status-info { background-color: #206694; }
         .analysis-content { color: #2c3e50; line-height: 1.6; font-size: 1.2em; font-weight: 500; }
         .analysis-timestamp { color: #7f8c8d; font-size: 0.9em; margin-top: 12px; padding-top: 12px; border-top: 1px solid #ecf0f1; }
         #scheduled-times { font-size: 1.4em; line-height: 1.8; }
@@ -35,12 +35,19 @@
             padding: 16px; margin-top: 20px; font-size: 0.95em; color: #856404; 
             text-align: center;
         }
+        .sr-only {
+            position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px;
+            overflow: hidden; clip: rect(0, 0, 0, 0); white-space: nowrap; border-width: 0;
+        }
     </style>
 </head>
 <body>
     <h1 style="text-align: center;">South Shields Metro Departures</h1>
     
-    <div id="predicted-departure">Predicted next departure time: <span id="prediction-time">Loading...</span></div>
+    <div id="predicted-departure" aria-live="polite">
+        <span id="status-label" class="sr-only"></span>
+        Predicted next departure time: <span id="prediction-time">Loading...</span>
+    </div>
     
     <div class="card">
         <h2>Next Scheduled Times</h2>
@@ -48,7 +55,11 @@
     </div>
     
     <div class="service-analysis">
-        <h2><span class="status-indicator status-info" id="statusIndicator"></span>Next scheduled Departure:</h2>
+        <h2>
+            <span class="status-indicator status-info" id="statusIndicator" aria-hidden="true"></span>
+            <span id="indicator-text" class="sr-only">Service status: info. </span>
+            Next Scheduled Departure:
+        </h2>
         <div id="analysisContent" class="analysis-content">Loading...</div>
         <div class="analysis-timestamp" id="analysisTimestamp"></div>
     </div>
@@ -81,7 +92,7 @@
             const schedule = getScheduleForDay();
             let upcomingTimes = [];
             if (schedule[currentHour]) {
-                const validMinutes = schedule[currentHour].filter(m => m > currentMinute);
+                const validMinutes = schedule[currentHour].filter(m => m >= currentMinute);
                 upcomingTimes.push(...validMinutes.map(m => ({hour: currentHour, minute: m})));
             }
             let hour = currentHour + 1;
@@ -97,9 +108,12 @@
         function displayScheduledTimes() {
             const scheduledDiv = document.getElementById('scheduled-times');
             const nextTimes = getNextScheduledTimes();
-            scheduledDiv.innerHTML = nextTimes.length > 0 
-                ? nextTimes.map(t => `${t.hour.toString().padStart(2,'0')}:${t.minute.toString().padStart(2,'0')}`).join('<br>')
-                : 'No more scheduled departures today';
+            if (nextTimes.length > 0) {
+                const listItems = nextTimes.map(t => `<li>${t.hour.toString().padStart(2,'0')}:${t.minute.toString().padStart(2,'0')}</li>`).join('');
+                scheduledDiv.innerHTML = `<ul style="list-style: none; padding: 0; margin: 0;">${listItems}</ul>`;
+            } else {
+                scheduledDiv.innerHTML = 'No more scheduled departures today';
+            }
         }
 
         async function fetchLiveData(endpoint) {
@@ -116,18 +130,21 @@
         async function fetchPrediction() {
             const data = await fetchLiveData('/api/times/CHI/2');
             const predictionSpan = document.getElementById('prediction-time');
+            const statusLabel = document.getElementById('status-label');
             
             if (data && data.length > 0) {
                 const now = new Date();
                 const predictedTime = new Date(now.getTime() + (data[0].dueIn - 2) * 60000);
                 predictionSpan.textContent = `${predictedTime.getHours().toString().padStart(2,'0')}:${predictedTime.getMinutes().toString().padStart(2,'0')}`;
-                predictionSpan.parentElement.style.background = '#27ae60'; // Green when live
+                predictionSpan.parentElement.style.background = '#1b7a43'; // Green when live
+                statusLabel.textContent = 'Live prediction: ';
             } else {
                 const nextTimes = getNextScheduledTimes();
                 predictionSpan.textContent = nextTimes.length > 0 
                     ? `${nextTimes[0].hour.toString().padStart(2,'0')}:${nextTimes[0].minute.toString().padStart(2,'0')}`
                     : 'No departures';
-                predictionSpan.parentElement.style.background = '#3498db'; // Blue when static
+                predictionSpan.parentElement.style.background = '#206694'; // Blue when static
+                statusLabel.textContent = 'Scheduled departure: ';
             }
         }
 
@@ -136,16 +153,29 @@
             const nextScheduled = getNextScheduledTimes();
             const analysisContent = document.getElementById('analysisContent');
             const statusIndicator = document.getElementById('statusIndicator');
+            const indicatorText = document.getElementById('indicator-text');
             const timestampDiv = document.getElementById('analysisTimestamp');
 
             if (nextScheduled.length === 0) {
                 analysisContent.textContent = 'Service has ended for the day.';
                 statusIndicator.className = 'status-indicator status-info';
+                indicatorText.textContent = 'Service status: info. ';
             } else {
                 const next = nextScheduled[0];
                 const minsUntil = next.hour * 60 + next.minute - (now.getHours() * 60 + now.getMinutes());
-                analysisContent.textContent = `${next.hour.toString().padStart(2,'0')}:${next.minute.toString().padStart(2,'0')} (${minsUntil} mins)`;
-                statusIndicator.className = 'status-indicator status-info';
+
+                let timeStr;
+                if (minsUntil === 0) {
+                    timeStr = 'Due now';
+                } else if (minsUntil === 1) {
+                    timeStr = '1 min';
+                } else {
+                    timeStr = `${minsUntil} mins`;
+                }
+
+                analysisContent.textContent = `${next.hour.toString().padStart(2,'0')}:${next.minute.toString().padStart(2,'0')} (${timeStr})`;
+                statusIndicator.className = 'status-indicator status-good';
+                indicatorText.textContent = 'Service status: good. ';
             }
             
             timestampDiv.textContent = `Updated: ${now.toLocaleTimeString('en-GB')}`;


### PR DESCRIPTION
### 🎨 Palette: Improve accessibility and UX of Metro Departures

#### 💡 What
- Updated status and departure background colors to meet WCAG AA contrast standards.
- Added screen-reader-only labels (`.sr-only`) to provide context for visual indicators (status dots, live/scheduled state).
- Enabled `aria-live="polite"` on the main departure display for real-time updates.
- Converted the scheduled times display from a text-based layout to a semantic `<ul>` list.
- Fixed a timing bug where trains departing in the current minute were filtered out.
- Added user-friendly countdown strings ("Due now", "1 min").

#### 🎯 Why
The previous UI had several accessibility barriers:
1. Low-contrast colors made it difficult for users with visual impairments to read status information.
2. The lack of ARIA attributes meant screen reader users were unaware of background color changes or live updates.
3. The flat text layout of the schedule was difficult to navigate with assistive technology.
4. The 60-second "dead zone" caused confusion by hiding imminent departures.

#### 📸 Before/After
- **Before:** Light blue (#3498db) and light green (#27ae60) backgrounds (contrast failures). Departures in current minute hidden. Simple text list.
- **After:** Accessible blue (#206694) and green (#1b7a43) backgrounds. "Due now" state active. Semantic HTML list.

#### ♿ Accessibility
- WCAG AA compliant contrast for all primary UI states.
- Semantic HTML (lists, headings).
- Screen reader context for all visual-only state changes.
- Live region support for dynamic content.

---
*PR created automatically by Jules for task [4032044902160053771](https://jules.google.com/task/4032044902160053771) started by @ColinPattinson*