### PR TITLE
🎨 Palette: Improve accessibility and UX of metro departures

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,5 @@
+# Palette's Journal - Critical UX/Accessibility Learnings
+
+## 2025-05-14 - Initial Assessment
+**Learning:** The application uses color-coded backgrounds (green for live, blue for static) to communicate state, which is not accessible to screen readers or color-blind users without additional context. The fallback to static times can also lead to a "dead zone" where departures in the current minute are hidden due to exclusive filtering.
+**Action:** Use `.sr-only` labels to communicate state textually, improve color contrast for WCAG AA compliance, and use inclusive filtering for time-based logic.

--- a/index.html
+++ b/index.html
@@ -6,8 +6,19 @@
     <title>South Shields Metro Times</title>
     <style>
         body { font-family: Arial, sans-serif; margin: 20px; }
+        .sr-only {
+            position: absolute;
+            width: 1px;
+            height: 1px;
+            padding: 0;
+            margin: -1px;
+            overflow: hidden;
+            clip: rect(0, 0, 0, 0);
+            white-space: nowrap;
+            border-width: 0;
+        }
         #predicted-departure {
-            background: #3498db; color: white; padding: 20px; border-radius: 8px; 
+            background: #206694; color: white; padding: 20px; border-radius: 8px;
             margin: 20px 0; font-size: 2em; text-align: center;
         }
         .card { 
@@ -15,7 +26,7 @@
             max-width: 600px; margin-left: auto; margin-right: auto;
         }
         .service-analysis { 
-            background: #fff; border: 2px solid #3498db; border-radius: 8px; 
+            background: #fff; border: 2px solid #206694; border-radius: 8px;
             padding: 24px; margin-top: 20px; box-shadow: 0 2px 8px rgba(0,0,0,0.1); 
         }
         .service-analysis h2 { 
@@ -23,10 +34,10 @@
             display: flex; align-items: center; gap: 10px; 
         }
         .status-indicator { width: 12px; height: 12px; border-radius: 50%; display: inline-block; }
-        .status-good { background-color: #27ae60; }
+        .status-good { background-color: #1b7a43; }
         .status-warning { background-color: #f39c12; }
         .status-error { background-color: #e74c3c; }
-        .status-info { background-color: #3498db; }
+        .status-info { background-color: #206694; }
         .analysis-content { color: #2c3e50; line-height: 1.6; font-size: 1.2em; font-weight: 500; }
         .analysis-timestamp { color: #7f8c8d; font-size: 0.9em; margin-top: 12px; padding-top: 12px; border-top: 1px solid #ecf0f1; }
         #scheduled-times { font-size: 1.4em; line-height: 1.8; }
@@ -40,7 +51,10 @@
 <body>
     <h1 style="text-align: center;">South Shields Metro Departures</h1>
     
-    <div id="predicted-departure">Predicted next departure time: <span id="prediction-time">Loading...</span></div>
+    <div id="predicted-departure" aria-live="polite">
+        <span id="status-label" class="sr-only">Checking status... </span>
+        Predicted next departure time: <span id="prediction-time">Loading...</span>
+    </div>
     
     <div class="card">
         <h2>Next Scheduled Times</h2>
@@ -48,7 +62,11 @@
     </div>
     
     <div class="service-analysis">
-        <h2><span class="status-indicator status-info" id="statusIndicator"></span>Next scheduled Departure:</h2>
+        <h2>
+            <span class="status-indicator status-info" id="statusIndicator" aria-hidden="true"></span>
+            <span id="indicator-text" class="sr-only">Information: </span>
+            Next Scheduled Departure:
+        </h2>
         <div id="analysisContent" class="analysis-content">Loading...</div>
         <div class="analysis-timestamp" id="analysisTimestamp"></div>
     </div>
@@ -81,7 +99,7 @@
             const schedule = getScheduleForDay();
             let upcomingTimes = [];
             if (schedule[currentHour]) {
-                const validMinutes = schedule[currentHour].filter(m => m > currentMinute);
+                const validMinutes = schedule[currentHour].filter(m => m >= currentMinute);
                 upcomingTimes.push(...validMinutes.map(m => ({hour: currentHour, minute: m})));
             }
             let hour = currentHour + 1;
@@ -97,9 +115,20 @@
         function displayScheduledTimes() {
             const scheduledDiv = document.getElementById('scheduled-times');
             const nextTimes = getNextScheduledTimes();
-            scheduledDiv.innerHTML = nextTimes.length > 0 
-                ? nextTimes.map(t => `${t.hour.toString().padStart(2,'0')}:${t.minute.toString().padStart(2,'0')}`).join('<br>')
-                : 'No more scheduled departures today';
+            if (nextTimes.length === 0) {
+                scheduledDiv.innerHTML = 'No more scheduled departures today';
+                return;
+            }
+            const list = document.createElement('ul');
+            list.style.listStyle = 'none';
+            list.style.padding = '0';
+            nextTimes.forEach(t => {
+                const li = document.createElement('li');
+                li.textContent = `${t.hour.toString().padStart(2,'0')}:${t.minute.toString().padStart(2,'0')}`;
+                list.appendChild(li);
+            });
+            scheduledDiv.innerHTML = '';
+            scheduledDiv.appendChild(list);
         }
 
         async function fetchLiveData(endpoint) {
@@ -116,18 +145,32 @@
         async function fetchPrediction() {
             const data = await fetchLiveData('/api/times/CHI/2');
             const predictionSpan = document.getElementById('prediction-time');
+            const statusLabel = document.getElementById('status-label');
+            const now = new Date();
             
             if (data && data.length > 0) {
-                const now = new Date();
-                const predictedTime = new Date(now.getTime() + (data[0].dueIn - 2) * 60000);
-                predictionSpan.textContent = `${predictedTime.getHours().toString().padStart(2,'0')}:${predictedTime.getMinutes().toString().padStart(2,'0')}`;
-                predictionSpan.parentElement.style.background = '#27ae60'; // Green when live
+                const dueInAdj = data[0].dueIn - 2;
+                if (dueInAdj <= 0) {
+                    predictionSpan.textContent = 'Due now';
+                } else {
+                    const predictedTime = new Date(now.getTime() + dueInAdj * 60000);
+                    predictionSpan.textContent = `${predictedTime.getHours().toString().padStart(2,'0')}:${predictedTime.getMinutes().toString().padStart(2,'0')}`;
+                }
+                predictionSpan.parentElement.style.background = '#1b7a43'; // Green when live
+                statusLabel.textContent = 'Live prediction: ';
             } else {
                 const nextTimes = getNextScheduledTimes();
-                predictionSpan.textContent = nextTimes.length > 0 
-                    ? `${nextTimes[0].hour.toString().padStart(2,'0')}:${nextTimes[0].minute.toString().padStart(2,'0')}`
-                    : 'No departures';
-                predictionSpan.parentElement.style.background = '#3498db'; // Blue when static
+                if (nextTimes.length > 0) {
+                    const next = nextTimes[0];
+                    const minsUntil = next.hour * 60 + next.minute - (now.getHours() * 60 + now.getMinutes());
+                    predictionSpan.textContent = minsUntil <= 0
+                        ? 'Due now'
+                        : `${next.hour.toString().padStart(2,'0')}:${next.minute.toString().padStart(2,'0')}`;
+                } else {
+                    predictionSpan.textContent = 'No departures';
+                }
+                predictionSpan.parentElement.style.background = '#206694'; // Blue when static
+                statusLabel.textContent = 'Scheduled departure: ';
             }
         }
 
@@ -136,16 +179,25 @@
             const nextScheduled = getNextScheduledTimes();
             const analysisContent = document.getElementById('analysisContent');
             const statusIndicator = document.getElementById('statusIndicator');
+            const indicatorText = document.getElementById('indicator-text');
             const timestampDiv = document.getElementById('analysisTimestamp');
 
             if (nextScheduled.length === 0) {
                 analysisContent.textContent = 'Service has ended for the day.';
                 statusIndicator.className = 'status-indicator status-info';
+                indicatorText.textContent = 'Information: ';
             } else {
                 const next = nextScheduled[0];
                 const minsUntil = next.hour * 60 + next.minute - (now.getHours() * 60 + now.getMinutes());
-                analysisContent.textContent = `${next.hour.toString().padStart(2,'0')}:${next.minute.toString().padStart(2,'0')} (${minsUntil} mins)`;
+                const timeStr = `${next.hour.toString().padStart(2,'0')}:${next.minute.toString().padStart(2,'0')}`;
+
+                if (minsUntil <= 0) {
+                    analysisContent.textContent = `${timeStr} (Due now)`;
+                } else {
+                    analysisContent.textContent = `${timeStr} (${minsUntil} ${minsUntil === 1 ? 'min' : 'mins'})`;
+                }
                 statusIndicator.className = 'status-indicator status-info';
+                indicatorText.textContent = 'Information: ';
             }
             
             timestampDiv.textContent = `Updated: ${now.toLocaleTimeString('en-GB')}`;


### PR DESCRIPTION
This PR implements several micro-UX and accessibility improvements to the South Shields Metro Departures app:

### ♿ Accessibility
- **Screen Reader Context:** Added visually hidden labels (`.sr-only`) to communicate "Live prediction" vs "Scheduled departure" status, which was previously only conveyed by color.
- **Dynamic Updates:** Added `aria-live="polite"` to the main departure container so screen readers announce time updates.
- **Color Contrast:** Switched to WCAG AA compliant colors:
  - Green (Live): `#1b7a43` (from `#27ae60`)
  - Blue (Scheduled): `#206694` (from `#3498db`)
- **Semantic HTML:** Replaced `<br>`-separated text with a proper `<ul>` list for the "Next Scheduled Times" section.
- **Service Status:** Added a visually hidden label for the status indicator dot.

### ✨ UX Improvements
- **"Due now" State:** Instead of showing 0 mins or hiding imminent trains, the UI now explicitly shows "Due now" when a train is departing within 1 minute.
- **Inclusive Filtering:** Fixed a bug where departures in the current minute were hidden.
- **Visual Consistency:** Updated headings to Title Case and synced border colors with the accessible blue theme.
- **Polish:** Added proper pluralization for the minute countdown (e.g., "1 min" vs "2 mins").

Verified with Playwright (video and screenshots captured).

---
*PR created automatically by Jules for task [14189021615817507198](https://jules.google.com/task/14189021615817507198) started by @ColinPattinson*