### PR TITLE
🎨 Palette: Accessibility and Clarity Enhancement

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,7 @@
+## 2025-05-15 - Screen Reader Context Pattern
+**Learning:** In a single-page app where status is indicated by color (e.g., Green for Live, Blue for Scheduled), screen reader users miss this critical context unless a visually hidden label (`.sr-only`) is updated alongside the visual change.
+**Action:** Use a hidden span within the `aria-live` region to explicitly state the data source or status when the UI state changes.
+
+## 2025-05-15 - Inclusive Time Filtering
+**Learning:** Using `m > currentMinute` in time calculations creates a "dead zone" where a train due within the current minute is hidden until the minute rolls over, even though it is technically the "next" train.
+**Action:** Use inclusive checks (`m >= currentMinute`) and map the 0-minute difference to a "Due now" state for better UX.

--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
     <style>
         body { font-family: Arial, sans-serif; margin: 20px; }
         #predicted-departure {
-            background: #3498db; color: white; padding: 20px; border-radius: 8px; 
+            background: #206694; color: white; padding: 20px; border-radius: 8px;
             margin: 20px 0; font-size: 2em; text-align: center;
         }
         .card { 
@@ -15,7 +15,7 @@
             max-width: 600px; margin-left: auto; margin-right: auto;
         }
         .service-analysis { 
-            background: #fff; border: 2px solid #3498db; border-radius: 8px; 
+            background: #fff; border: 2px solid #206694; border-radius: 8px;
             padding: 24px; margin-top: 20px; box-shadow: 0 2px 8px rgba(0,0,0,0.1); 
         }
         .service-analysis h2 { 
@@ -23,10 +23,14 @@
             display: flex; align-items: center; gap: 10px; 
         }
         .status-indicator { width: 12px; height: 12px; border-radius: 50%; display: inline-block; }
-        .status-good { background-color: #27ae60; }
+        .status-good { background-color: #1b7a43; }
         .status-warning { background-color: #f39c12; }
         .status-error { background-color: #e74c3c; }
-        .status-info { background-color: #3498db; }
+        .status-info { background-color: #206694; }
+        .sr-only {
+            position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px;
+            overflow: hidden; clip: rect(0, 0, 0, 0); white-space: nowrap; border: 0;
+        }
         .analysis-content { color: #2c3e50; line-height: 1.6; font-size: 1.2em; font-weight: 500; }
         .analysis-timestamp { color: #7f8c8d; font-size: 0.9em; margin-top: 12px; padding-top: 12px; border-top: 1px solid #ecf0f1; }
         #scheduled-times { font-size: 1.4em; line-height: 1.8; }
@@ -40,15 +44,22 @@
 <body>
     <h1 style="text-align: center;">South Shields Metro Departures</h1>
     
-    <div id="predicted-departure">Predicted next departure time: <span id="prediction-time">Loading...</span></div>
+    <div id="predicted-departure" aria-live="polite">
+        <span id="status-label" class="sr-only">Scheduled departure:</span>
+        Predicted next departure time: <span id="prediction-time">Loading...</span>
+    </div>
     
     <div class="card">
         <h2>Next Scheduled Times</h2>
-        <div id="scheduled-times">Loading...</div>
+        <ul id="scheduled-times" style="list-style: none; padding: 0;">Loading...</ul>
     </div>
     
     <div class="service-analysis">
-        <h2><span class="status-indicator status-info" id="statusIndicator"></span>Next scheduled Departure:</h2>
+        <h2>
+            <span class="status-indicator status-info" id="statusIndicator" aria-hidden="true"></span>
+            <span id="indicator-text" class="sr-only">Service status: Normal</span>
+            Next Scheduled Departure:
+        </h2>
         <div id="analysisContent" class="analysis-content">Loading...</div>
         <div class="analysis-timestamp" id="analysisTimestamp"></div>
     </div>
@@ -81,7 +92,7 @@
             const schedule = getScheduleForDay();
             let upcomingTimes = [];
             if (schedule[currentHour]) {
-                const validMinutes = schedule[currentHour].filter(m => m > currentMinute);
+                const validMinutes = schedule[currentHour].filter(m => m >= currentMinute);
                 upcomingTimes.push(...validMinutes.map(m => ({hour: currentHour, minute: m})));
             }
             let hour = currentHour + 1;
@@ -98,8 +109,8 @@
             const scheduledDiv = document.getElementById('scheduled-times');
             const nextTimes = getNextScheduledTimes();
             scheduledDiv.innerHTML = nextTimes.length > 0 
-                ? nextTimes.map(t => `${t.hour.toString().padStart(2,'0')}:${t.minute.toString().padStart(2,'0')}`).join('<br>')
-                : 'No more scheduled departures today';
+                ? nextTimes.map(t => `<li>${t.hour.toString().padStart(2,'0')}:${t.minute.toString().padStart(2,'0')}</li>`).join('')
+                : '<li>No more scheduled departures today</li>';
         }
 
         async function fetchLiveData(endpoint) {
@@ -116,18 +127,21 @@
         async function fetchPrediction() {
             const data = await fetchLiveData('/api/times/CHI/2');
             const predictionSpan = document.getElementById('prediction-time');
+            const statusLabel = document.getElementById('status-label');
             
             if (data && data.length > 0) {
                 const now = new Date();
                 const predictedTime = new Date(now.getTime() + (data[0].dueIn - 2) * 60000);
                 predictionSpan.textContent = `${predictedTime.getHours().toString().padStart(2,'0')}:${predictedTime.getMinutes().toString().padStart(2,'0')}`;
-                predictionSpan.parentElement.style.background = '#27ae60'; // Green when live
+                predictionSpan.parentElement.style.background = '#1b7a43'; // Green when live
+                statusLabel.textContent = 'Live prediction:';
             } else {
                 const nextTimes = getNextScheduledTimes();
                 predictionSpan.textContent = nextTimes.length > 0 
                     ? `${nextTimes[0].hour.toString().padStart(2,'0')}:${nextTimes[0].minute.toString().padStart(2,'0')}`
                     : 'No departures';
-                predictionSpan.parentElement.style.background = '#3498db'; // Blue when static
+                predictionSpan.parentElement.style.background = '#206694'; // Blue when static
+                statusLabel.textContent = 'Scheduled departure:';
             }
         }
 
@@ -136,16 +150,27 @@
             const nextScheduled = getNextScheduledTimes();
             const analysisContent = document.getElementById('analysisContent');
             const statusIndicator = document.getElementById('statusIndicator');
+            const indicatorText = document.getElementById('indicator-text');
             const timestampDiv = document.getElementById('analysisTimestamp');
 
             if (nextScheduled.length === 0) {
                 analysisContent.textContent = 'Service has ended for the day.';
                 statusIndicator.className = 'status-indicator status-info';
+                indicatorText.textContent = 'Service status: Service ended';
             } else {
                 const next = nextScheduled[0];
-                const minsUntil = next.hour * 60 + next.minute - (now.getHours() * 60 + now.getMinutes());
-                analysisContent.textContent = `${next.hour.toString().padStart(2,'0')}:${next.minute.toString().padStart(2,'0')} (${minsUntil} mins)`;
+                const minsUntil = (next.hour * 60 + next.minute) - (now.getHours() * 60 + now.getMinutes());
+
+                let timeString;
+                if (minsUntil <= 0) {
+                    timeString = 'Due now';
+                } else {
+                    timeString = `${minsUntil} ${minsUntil === 1 ? 'min' : 'mins'}`;
+                }
+
+                analysisContent.textContent = `${next.hour.toString().padStart(2,'0')}:${next.minute.toString().padStart(2,'0')} (${timeString})`;
                 statusIndicator.className = 'status-indicator status-info';
+                indicatorText.textContent = 'Service status: Normal';
             }
             
             timestampDiv.textContent = `Updated: ${now.toLocaleTimeString('en-GB')}`;


### PR DESCRIPTION
I have implemented a comprehensive micro-UX and accessibility enhancement for the South Shields Metro Departures app.

### Key Improvements:

1.  **♿ Accessibility First:**
    *   Added `aria-live="polite"` to the main departure display so updates are announced to screen readers.
    *   Introduced a visually hidden `.sr-only` class to provide textual context ("Live prediction:" vs "Scheduled departure:") that was previously only communicated via color.
    *   Improved color contrast: Updated the green and blue backgrounds to higher-contrast versions (#1b7a43 and #206694) to ensure readability and WCAG AA compliance.
    *   Converted the scheduled times list into a semantic `<ul>` for better navigation with assistive technologies.

2.  **✨ Natural Interactions:**
    *   Updated the countdown logic to show "Due now" instead of "0 mins" for immediate departures.
    *   Ensured correct pluralization (e.g., "1 min" vs "2 mins").
    *   Fixed a bug where trains scheduled for the current minute were filtered out (the "dead zone").

3.  **🎨 Visual Polish:**
    *   Aligned the service analysis border color with the new accessibility-compliant blue.
    *   Standardized headings to Title Case (e.g., "Next Scheduled Departure").

### Verification:
I verified these changes using Playwright scripts that mock both the API and various times to confirm the "Live", "Scheduled", "Due now", and pluralization states work as intended.

---
*PR created automatically by Jules for task [3594456413794787436](https://jules.google.com/task/3594456413794787436) started by @ColinPattinson*