### PR TITLE
🎨 Palette: Improve accessibility and UX of departure display

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,9 @@
+## 2025-05-14 - [Semantic Lists & Real-time States]
+**Learning:** Using inclusive minute filtering (>=) for departure boards prevents a 60-second 'dead zone' where upcoming trains are hidden. Combining this with "Due now" text provides immediate, intuitive feedback that matches user expectations for live transport displays.
+
+**Action:** Always check if time-based filters should be inclusive of the current minute to avoid missing immediate events.
+
+## 2025-05-14 - [Screen Reader Context Pattern]
+**Learning:** Visual-only indicators (like background color changes for 'Live' vs 'Scheduled' states) are inaccessible to screen reader users unless accompanied by text. The 'Screen Reader Context Pattern' (using .sr-only utility to provide descriptive labels) bridges this gap without cluttering the visual UI.
+
+**Action:** Pair every significant visual state change with a corresponding visually hidden text update for assistive technology.

--- a/index.html
+++ b/index.html
@@ -7,15 +7,17 @@
     <style>
         body { font-family: Arial, sans-serif; margin: 20px; }
         #predicted-departure {
-            background: #3498db; color: white; padding: 20px; border-radius: 8px; 
+            color: white; padding: 20px; border-radius: 8px;
             margin: 20px 0; font-size: 2em; text-align: center;
         }
+        #predicted-departure.is-live { background: #1b7a43; }
+        #predicted-departure.is-scheduled { background: #206694; }
         .card { 
             background: #f5f5f5; padding: 20px; border-radius: 8px; margin: 20px 0;
             max-width: 600px; margin-left: auto; margin-right: auto;
         }
         .service-analysis { 
-            background: #fff; border: 2px solid #3498db; border-radius: 8px; 
+            background: #fff; border: 2px solid #206694; border-radius: 8px;
             padding: 24px; margin-top: 20px; box-shadow: 0 2px 8px rgba(0,0,0,0.1); 
         }
         .service-analysis h2 { 
@@ -23,10 +25,10 @@
             display: flex; align-items: center; gap: 10px; 
         }
         .status-indicator { width: 12px; height: 12px; border-radius: 50%; display: inline-block; }
-        .status-good { background-color: #27ae60; }
+        .status-good { background-color: #1b7a43; }
         .status-warning { background-color: #f39c12; }
         .status-error { background-color: #e74c3c; }
-        .status-info { background-color: #3498db; }
+        .status-info { background-color: #206694; }
         .analysis-content { color: #2c3e50; line-height: 1.6; font-size: 1.2em; font-weight: 500; }
         .analysis-timestamp { color: #7f8c8d; font-size: 0.9em; margin-top: 12px; padding-top: 12px; border-top: 1px solid #ecf0f1; }
         #scheduled-times { font-size: 1.4em; line-height: 1.8; }
@@ -35,20 +37,31 @@
             padding: 16px; margin-top: 20px; font-size: 0.95em; color: #856404; 
             text-align: center;
         }
+        .sr-only {
+            position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px;
+            overflow: hidden; clip: rect(0, 0, 0, 0); border: 0;
+        }
     </style>
 </head>
 <body>
     <h1 style="text-align: center;">South Shields Metro Departures</h1>
     
-    <div id="predicted-departure">Predicted next departure time: <span id="prediction-time">Loading...</span></div>
+    <div id="predicted-departure" aria-live="polite">
+        <span id="status-label" class="sr-only">Checking status...</span>
+        Next departure: <span id="prediction-time">Loading...</span>
+    </div>
     
     <div class="card">
         <h2>Next Scheduled Times</h2>
-        <div id="scheduled-times">Loading...</div>
+        <ul id="scheduled-times" style="list-style: none; padding: 0; margin: 0;">Loading...</ul>
     </div>
     
     <div class="service-analysis">
-        <h2><span class="status-indicator status-info" id="statusIndicator"></span>Next scheduled Departure:</h2>
+        <h2>
+            <span class="status-indicator status-info" id="statusIndicator" aria-hidden="true"></span>
+            <span id="indicator-text" class="sr-only">Service status: Info.</span>
+            Next Scheduled Departure:
+        </h2>
         <div id="analysisContent" class="analysis-content">Loading...</div>
         <div class="analysis-timestamp" id="analysisTimestamp"></div>
     </div>
@@ -81,7 +94,7 @@
             const schedule = getScheduleForDay();
             let upcomingTimes = [];
             if (schedule[currentHour]) {
-                const validMinutes = schedule[currentHour].filter(m => m > currentMinute);
+                const validMinutes = schedule[currentHour].filter(m => m >= currentMinute);
                 upcomingTimes.push(...validMinutes.map(m => ({hour: currentHour, minute: m})));
             }
             let hour = currentHour + 1;
@@ -95,11 +108,11 @@
         }
 
         function displayScheduledTimes() {
-            const scheduledDiv = document.getElementById('scheduled-times');
+            const scheduledList = document.getElementById('scheduled-times');
             const nextTimes = getNextScheduledTimes();
-            scheduledDiv.innerHTML = nextTimes.length > 0 
-                ? nextTimes.map(t => `${t.hour.toString().padStart(2,'0')}:${t.minute.toString().padStart(2,'0')}`).join('<br>')
-                : 'No more scheduled departures today';
+            scheduledList.innerHTML = nextTimes.length > 0
+                ? nextTimes.map(t => `<li>${t.hour.toString().padStart(2,'0')}:${t.minute.toString().padStart(2,'0')}</li>`).join('')
+                : '<li>No more scheduled departures today</li>';
         }
 
         async function fetchLiveData(endpoint) {
@@ -116,18 +129,22 @@
         async function fetchPrediction() {
             const data = await fetchLiveData('/api/times/CHI/2');
             const predictionSpan = document.getElementById('prediction-time');
+            const statusLabel = document.getElementById('status-label');
+            const container = predictionSpan.parentElement;
             
             if (data && data.length > 0) {
                 const now = new Date();
                 const predictedTime = new Date(now.getTime() + (data[0].dueIn - 2) * 60000);
                 predictionSpan.textContent = `${predictedTime.getHours().toString().padStart(2,'0')}:${predictedTime.getMinutes().toString().padStart(2,'0')}`;
-                predictionSpan.parentElement.style.background = '#27ae60'; // Green when live
+                container.className = 'is-live';
+                statusLabel.textContent = 'Live prediction:';
             } else {
                 const nextTimes = getNextScheduledTimes();
                 predictionSpan.textContent = nextTimes.length > 0 
                     ? `${nextTimes[0].hour.toString().padStart(2,'0')}:${nextTimes[0].minute.toString().padStart(2,'0')}`
                     : 'No departures';
-                predictionSpan.parentElement.style.background = '#3498db'; // Blue when static
+                container.className = 'is-scheduled';
+                statusLabel.textContent = 'Scheduled departure:';
             }
         }
 
@@ -136,16 +153,26 @@
             const nextScheduled = getNextScheduledTimes();
             const analysisContent = document.getElementById('analysisContent');
             const statusIndicator = document.getElementById('statusIndicator');
+            const indicatorText = document.getElementById('indicator-text');
             const timestampDiv = document.getElementById('analysisTimestamp');
 
             if (nextScheduled.length === 0) {
                 analysisContent.textContent = 'Service has ended for the day.';
                 statusIndicator.className = 'status-indicator status-info';
+                indicatorText.textContent = 'Service status: Info.';
             } else {
                 const next = nextScheduled[0];
                 const minsUntil = next.hour * 60 + next.minute - (now.getHours() * 60 + now.getMinutes());
-                analysisContent.textContent = `${next.hour.toString().padStart(2,'0')}:${next.minute.toString().padStart(2,'0')} (${minsUntil} mins)`;
-                statusIndicator.className = 'status-indicator status-info';
+                let timeStr = `${next.hour.toString().padStart(2,'0')}:${next.minute.toString().padStart(2,'0')}`;
+
+                if (minsUntil === 0) {
+                    analysisContent.textContent = `${timeStr} (Due now)`;
+                } else {
+                    analysisContent.textContent = `${timeStr} (${minsUntil} ${minsUntil === 1 ? 'min' : 'mins'})`;
+                }
+
+                statusIndicator.className = 'status-indicator status-good';
+                indicatorText.textContent = 'Service status: Good.';
             }
             
             timestampDiv.textContent = `Updated: ${now.toLocaleTimeString('en-GB')}`;


### PR DESCRIPTION
This PR implements a suite of micro-UX and accessibility improvements to the South Shields Metro Departures interface.

💡 **What:** 
- Added a `.sr-only` utility for accessible hidden text.
- Switched scheduled times from `<br>` to a semantic `<ul>`.
- Refined the departure board colors to meet WCAG AA contrast guidelines.
- Implemented "Due now" for trains departing in the current minute and added proper pluralization for "min/mins".
- Added `aria-live="polite"` and visually hidden status labels to communicate "Live" vs "Scheduled" states to screen readers.

🎯 **Why:** 
The previous interface lacked semantic structure, had low color contrast in certain states, and didn't clearly communicate whether a time was a live prediction or a scheduled fallback to assistive technologies. The "Due now" logic provides a more intuitive experience similar to professional transit boards.

♿ **Accessibility:**
- Improved color contrast.
- Semantic HTML structure.
- Screen reader announcements for state updates.
- Descriptive labels for visual indicators.

---
*PR created automatically by Jules for task [17740689964143591449](https://jules.google.com/task/17740689964143591449) started by @ColinPattinson*